### PR TITLE
prefer json4s-ast for json4s use in jawn

### DIFF
--- a/support/json4s/build.sbt
+++ b/support/json4s/build.sbt
@@ -1,7 +1,7 @@
 name := "json4s-support"
 
 libraryDependencies ++= Seq(
-  "org.json4s" %% "json4s-native" % "3.2.10"
+  "org.json4s" %% "json4s-ast" % "3.2.10"
 )
 
 seq(bintrayResolverSettings: _*)

--- a/support/json4s/src/main/scala/Parser.scala
+++ b/support/json4s/src/main/scala/Parser.scala
@@ -1,7 +1,7 @@
 package jawn
 package support.json4s
 
-import org.json4s._
+import org.json4s.JsonAST._
 
 object Parser extends SupportParser[JValue] {
 


### PR DESCRIPTION
If all the facades are doing is emitting support-specific types, it may be to depend on json4s-ast rather tan json4s-native. the native package includes parsing logic not used here an some other stuff in core which just [alias](https://github.com/json4s/json4s/blob/master/core/src/main/scala/org/json4s/package.scala#L23-L41) the ast at the json4s package level. This should also make the jawn facade for json4s a better fit if you depend on one of the other json4s-\* flavored parsers: json4s-jackson, ect.
