### PR TITLE
Return failures from AsyncParser

### DIFF
--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -225,6 +225,7 @@ final class AsyncParser[J] protected[jawn] (
           results.append(value)
         }
       }
+      Right(results)
     } catch {
       case e: AsyncException =>
         // we ran out of data, so return what we have so far
@@ -234,7 +235,6 @@ final class AsyncParser[J] protected[jawn] (
         // we hit a parser error, so return that error and results so far
         Left(e)
     }
-    Right(results)
   }
 
   // every 1M we shift our array back by 1M.

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -68,6 +68,10 @@ class SyntaxCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChe
     val bb = ByteBuffer.wrap(s.getBytes("UTF-8"))
     val r2 = Parser.parseFromByteBuffer(bb)(NullFacade).isSuccess
     if (r1 == r2) r1 else sys.error(s"String/ByteBuffer parsing disagree($r1, $r2): $s")
+
+    val async = AsyncParser[Unit](AsyncParser.SingleValue)
+    val r3 = async.absorb(s)(NullFacade).isRight && async.finish()(NullFacade).isRight
+    if (r1 == r3) r1 else sys.error(s"Sync/Async parsing disagree($r1, $r2): $s")
   }
 
   property("syntax-checking") {


### PR DESCRIPTION
AsyncParser doesn't currently return `Left` on bad input.  The result of the catch block is shadowed by the final `Right`.

Needs one test fix before it's mergeable:

```
[info] - 0e is invalid *** FAILED ***
[info]   java.lang.RuntimeException: Sync/Async parsing disagree(false, false): 0e
```
