### PR TITLE
Fix issue with numeric equality pointed out by Jon Pretty.

### DIFF
--- a/ast/src/main/scala/jawn/JValue.scala
+++ b/ast/src/main/scala/jawn/JValue.scala
@@ -46,7 +46,7 @@ case class LongNum(n: Long) extends JNum {
     that match {
       case LongNum(n2) => n == n2
       case DoubleNum(n2) => n == n2
-      case DeferNum(s) => n.toString == s
+      case j: DeferNum => n == j.toDouble
       case _ => false
     }
 }
@@ -58,7 +58,7 @@ case class DoubleNum(n: Double) extends JNum {
     that match {
       case LongNum(n2) => n == n2
       case DoubleNum(n2) => n == n2
-      case DeferNum(s) => n.toString == s
+      case j: DeferNum => n == j.toDouble
       case _ => false
     }
 }
@@ -68,9 +68,7 @@ case class DeferNum(s: String) extends JNum {
   override def hashCode: Int = toDouble.##
   override def equals(that: Any): Boolean =
     that match {
-      case LongNum(n2) => s == n2.toString
-      case DoubleNum(n2) => s == n2.toString
-      case DeferNum(s2) => s == s2
+      case rhs: JNum => toDouble == rhs.toDouble
       case _ => false
     }
 }

--- a/ast/src/test/scala/jawn/ParseCheck.scala
+++ b/ast/src/test/scala/jawn/ParseCheck.scala
@@ -155,4 +155,25 @@ class AstCheck extends PropSpec with Matchers with GeneratorDrivenPropertyChecks
       }
     }
   }
+
+  property("ignore trailing zeros") {
+    forAll { (n: Int) =>
+      val s = n.toString
+      val n1 = LongNum(n)
+      val n2 = DoubleNum(n)
+      val n3 = DeferNum(s + ".00")
+
+      def check(j: JValue) {
+        j shouldBe n1; n1 shouldBe j
+        j shouldBe n2; n2 shouldBe j
+      }
+
+      check(DeferNum(s))
+      check(DeferNum(s + ".0"))
+      check(DeferNum(s + ".00"))
+      check(DeferNum(s + ".000"))
+      check(DeferNum(s + "e0"))
+      check(DeferNum(s + ".0e0"))
+    }
+  }
 }


### PR DESCRIPTION
This commit standardizes on using Double precision for equality.
This is consistent with how Javascript would actually interpret
these values.

Fixes #18.
