### PR TITLE
Upgrade argonaut to 6.1-M5.

### DIFF
--- a/support/argonaut/build.sbt
+++ b/support/argonaut/build.sbt
@@ -1,5 +1,5 @@
 name := "argonaut-support"
 
 libraryDependencies ++= Seq(
-  "io.argonaut" %% "argonaut" % "6.0.4"
+  "io.argonaut" %% "argonaut" % "6.1-M5"
 )

--- a/support/argonaut/src/main/scala/Parser.scala
+++ b/support/argonaut/src/main/scala/Parser.scala
@@ -10,8 +10,8 @@ object Parser extends SupportParser[Json] {
       def jnull() = Json.jNull
       def jfalse() = Json.jFalse
       def jtrue() = Json.jTrue
-      def jnum(s: String) = Json.jNumber(java.lang.Double.parseDouble(s))
-      def jint(s: String) = Json.jNumber(java.lang.Double.parseDouble(s))
+      def jnum(s: String) = Json.jNumberOrNull(java.lang.Double.parseDouble(s))
+      def jint(s: String) = Json.jNumberOrNull(java.lang.Double.parseDouble(s))
       def jstring(s: String) = Json.jString(s)
 
       def singleContext() = new FContext[Json] {


### PR DESCRIPTION
Argonaut 6.1 tightens up JNumber, forbidding invalid infinite and NaN values.  These are lossily parsed as nulls.

Fixes #22.
