### PR TITLE
Use non-empty representation of stack

### DIFF
--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -14,7 +14,7 @@ object AsyncParser {
   case object SingleValue extends Mode(-1, -1)
 
   def apply[J](mode: Mode = SingleValue): AsyncParser[J] =
-    new AsyncParser(state = mode.start, curr = 0, stack = Nil,
+    new AsyncParser(state = mode.start, curr = 0, context = null, stack = Nil,
       data = new Array[Byte](131072), len = 0, allocated = 131072,
       offset = 0, done = false, streamMode = mode.value)
 }
@@ -60,6 +60,7 @@ object AsyncParser {
 final class AsyncParser[J] protected[jawn] (
   protected[jawn] var state: Int,
   protected[jawn] var curr: Int,
+  protected[jawn] var context: FContext[J],
   protected[jawn] var stack: List[FContext[J]],
   protected[jawn] var data: Array[Byte],
   protected[jawn] var len: Int,
@@ -75,7 +76,7 @@ final class AsyncParser[J] protected[jawn] (
   protected[this] final def column(i: Int) = i - pos
 
   final def copy() =
-    new AsyncParser(state, curr, stack, data.clone, len, allocated, offset, done, streamMode)
+    new AsyncParser(state, curr, context, stack, data.clone, len, allocated, offset, done, streamMode)
 
   final def absorb(buf: ByteBuffer)(implicit facade: Facade[J]): Either[ParseException, Seq[J]] = {
     done = false
@@ -210,7 +211,7 @@ final class AsyncParser[J] protected[jawn] (
           val (value, j) = if (state <= 0) {
             parse(offset)
           } else {
-            rparse(state, curr, stack)
+            rparse(state, curr, context, stack)
           }
           if (streamMode > 0) {
             state = ASYNC_POSTVAL
@@ -221,6 +222,7 @@ final class AsyncParser[J] protected[jawn] (
           }
           curr = j
           offset = j
+          context = null
           stack = Nil
           results.append(value)
         }
@@ -265,9 +267,10 @@ final class AsyncParser[J] protected[jawn] (
    * arguments are the exact arguments we can pass to rparse to
    * continue where we left off.
    */
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]) {
+  protected[this] final def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]) {
     this.state = state
     this.curr = i
+    this.context = context
     this.stack = stack
   }
 

--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -25,7 +25,7 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
 
   protected[this] final def close() { src.position(src.limit) }
   protected[this] final def reset(i: Int): Int = i
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]) {}
+  protected[this] final def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]) {}
   protected[this] final def byte(i: Int): Byte = src.get(i + start)
   protected[this] final def at(i: Int): Char = src.get(i + start).toChar
 

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -112,7 +112,7 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
       i
     }
 
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]): Unit = ()
+  protected[this] final def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]): Unit = ()
 
   /**
    * This is a specialized accessor for the case where our underlying

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -66,7 +66,7 @@ abstract class Parser[J] {
    * The checkpoint() method is used to allow some parsers to store
    * their progress.
    */
-  protected[this] def checkpoint(state: Int, i: Int, stack: List[FContext[J]]): Unit
+  protected[this] def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]): Unit
 
   /**
    * Should be called when parsing is finished.
@@ -337,8 +337,8 @@ abstract class Parser[J] {
 
       // if we have a recursive top-level structure, we'll delegate the parsing
       // duties to our good friend rparse().
-      case '[' => rparse(ARRBEG, i + 1, facade.arrayContext() :: Nil)
-      case '{' => rparse(OBJBEG, i + 1, facade.objectContext() :: Nil)
+      case '[' => rparse(ARRBEG, i + 1, facade.arrayContext(), Nil)
+      case '{' => rparse(OBJBEG, i + 1, facade.objectContext(), Nil)
 
       // we have a single top-level number
       case '-' | '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' =>
@@ -380,41 +380,44 @@ abstract class Parser[J] {
    * improvements.
    */
   @tailrec
-  protected[this] final def rparse(state: Int, j: Int, stack: List[FContext[J]])(implicit facade: Facade[J]): (J, Int) = {
+  protected[this] final def rparse(
+    state: Int,
+    j: Int,
+    context: FContext[J],
+    stack: List[FContext[J]]
+  )(implicit facade: Facade[J]): (J, Int) = {
     val i = reset(j)
-    checkpoint(state, i, stack)
+    checkpoint(state, i, context, stack)
 
     val c = at(i)
 
     if (c == '\n') {
       newline(i)
-      rparse(state, i + 1, stack)
+      rparse(state, i + 1, context, stack)
     } else if (c == ' ' || c == '\t' || c == '\r') {
-      rparse(state, i + 1, stack)
+      rparse(state, i + 1, context, stack)
     } else if (state == DATA) {
       // we are inside an object or array expecting to see data
       if (c == '[') {
-        rparse(ARRBEG, i + 1, facade.arrayContext() :: stack)
+        rparse(ARRBEG, i + 1, facade.arrayContext(), context :: stack)
       } else if (c == '{') {
-        rparse(OBJBEG, i + 1, facade.objectContext() :: stack)
+        rparse(OBJBEG, i + 1, facade.objectContext(), context :: stack)
       } else {
-        val ctxt = stack.head
-
         if ((c >= '0' && c <= '9') || c == '-') {
-          val j = parseNum(i, ctxt)
-          rparse(if (ctxt.isObj) OBJEND else ARREND, j, stack)
+          val j = parseNum(i, context)
+          rparse(if (context.isObj) OBJEND else ARREND, j, context, stack)
         } else if (c == '"') {
-          val j = parseString(i, ctxt)
-          rparse(if (ctxt.isObj) OBJEND else ARREND, j, stack)
+          val j = parseString(i, context)
+          rparse(if (context.isObj) OBJEND else ARREND, j, context, stack)
         } else if (c == 't') {
-          ctxt.add(parseTrue(i))
-          rparse(if (ctxt.isObj) OBJEND else ARREND, i + 4, stack)
+          context.add(parseTrue(i))
+          rparse(if (context.isObj) OBJEND else ARREND, i + 4, context, stack)
         } else if (c == 'f') {
-          ctxt.add(parseFalse(i))
-          rparse(if (ctxt.isObj) OBJEND else ARREND, i + 5, stack)
+          context.add(parseFalse(i))
+          rparse(if (context.isObj) OBJEND else ARREND, i + 5, context, stack)
         } else if (c == 'n') {
-          ctxt.add(parseNull(i))
-          rparse(if (ctxt.isObj) OBJEND else ARREND, i + 4, stack)
+          context.add(parseNull(i))
+          rparse(if (context.isObj) OBJEND else ARREND, i + 4, context, stack)
         } else {
           die(i, "expected json value")
         }
@@ -426,54 +429,47 @@ abstract class Parser[J] {
       // we are inside an array or object and have seen a key or a closing
       // brace, respectively.
       if (stack.isEmpty) {
-        error("invalid stack")
+        (context.finish, i + 1)
       } else {
-        val ctxt1 = stack.head
-        val tail = stack.tail
-
-        if (tail.isEmpty) {
-          (ctxt1.finish, i + 1)
-        } else {
-          val ctxt2 = tail.head
-          ctxt2.add(ctxt1.finish)
-          rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, tail)
-        }
+        val ctxt2 = stack.head
+        ctxt2.add(context.finish)
+        rparse(if (ctxt2.isObj) OBJEND else ARREND, i + 1, ctxt2, stack.tail)
       }
     } else if (state == KEY) {
       // we are in an object expecting to see a key.
       if (c == '"') {
-        val j = parseString(i, stack.head)
-        rparse(SEP, j, stack)
+        val j = parseString(i, context)
+        rparse(SEP, j, context, stack)
       } else {
         die(i, "expected \"")
       }
     } else if (state == SEP) {
       // we are in an object just after a key, expecting to see a colon.
       if (c == ':') {
-        rparse(DATA, i + 1, stack)
+        rparse(DATA, i + 1, context, stack)
       } else {
         die(i, "expected :")
       }
     } else if (state == ARREND) {
       // we are in an array, expecting to see a comma (before more data).
       if (c == ',') {
-        rparse(DATA, i + 1, stack)
+        rparse(DATA, i + 1, context, stack)
       } else {
         die(i, "expected ] or ,")
       }
     } else if (state == OBJEND) {
       // we are in an object, expecting to see a comma (before more data).
       if (c == ',') {
-        rparse(KEY, i + 1, stack)
+        rparse(KEY, i + 1, context, stack)
       } else {
         die(i, "expected } or ,")
       }
     } else if (state == ARRBEG) {
       // we are starting an array, expecting to see data or a closing bracket.
-      rparse(DATA, i, stack)
+      rparse(DATA, i, context, stack)
     } else {
       // we are starting an object, expecting to see a key or a closing brace.
-      rparse(KEY, i, stack)
+      rparse(KEY, i, context, stack)
     }
   }
 }

--- a/parser/src/main/scala/jawn/StringParser.scala
+++ b/parser/src/main/scala/jawn/StringParser.scala
@@ -17,7 +17,7 @@ private[jawn] final class StringParser[J](s: String) extends SyncParser[J] with 
   final def column(i: Int) = i
   final def newline(i: Int) { line += 1 }
   final def reset(i: Int): Int = i
-  final def checkpoint(state: Int, i: Int, stack: List[FContext[J]]) {}
+  final def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]) {}
   final def at(i: Int): Char = s.charAt(i)
   final def at(i: Int, j: Int): CharSequence = s.substring(i, j)
   final def atEof(i: Int) = i == s.length


### PR DESCRIPTION
This doesn't seem to affect performance in a measurable way but it's arguably a little cleaner—the stack can never be empty, so we can pass a head and tail to `rparse` instead of a list, which means we don't have to handle the empty case, have direct access to the head, etc. I'm not sure it's worth changing but wanted to open the PR just in case.