### PR TITLE
Typelevel-ification

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,13 @@ Jawn's AST is intended to be very lightweight and simple. It supports
 simple access, and limited mutable updates. It intentionally lacks the
 power and sophistication of many other JSON libraries.
 
+### Community
+
+People are expected to follow the
+[Typelevel Code of Conduct](http://typelevel.org/conduct.html) when
+discussing Jawn on GitHub, the Gitter channel, or other
+venues.
+
 ### Copyright and License
 
 All code is available to you under the MIT license, available at

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ your own SBT project:
 resolvers += Resolver.sonatypeRepo("releases")
 
 // use this if you just want jawn's parser, and will implement your own facade
-libraryDependencies += "org.spire-math" %% "jawn-parser" % "0.13.0"
+libraryDependencies += "org.typelevel" %% "jawn-parser" % "0.14.0"
 
 // use this if you want jawn's parser and also jawn's ast
-libraryDependencies += "org.spire-math" %% "jawn-ast" % "0.13.0"
+libraryDependencies += "org.typelevel" %% "jawn-ast" % "0.14.0"
 ```
 
 If you want to use Jawn's parser with another project's AST, see the
@@ -56,7 +56,7 @@ If you want to use Jawn's parser with another project's AST, see the
 you would say:
 
 ```scala
-libraryDependencies += "org.spire-math" %% "jawn-spray" % "0.13.0"
+libraryDependencies += "org.typelevel" %% "jawn-spray" % "0.14.0"
 ```
 
 There are a few reasons you might want to do this:
@@ -102,9 +102,9 @@ the parser with data as it is available. There are three modes:
 Here's an example:
 
 ```scala
-import jawn.ast
-import jawn.AsyncParser
-import jawn.ParseException
+import org.typelevel.jawn.ast
+import org.typelevel.jawn.AsyncParser
+import org.typelevel.jawn.ParseException
 
 val p = ast.JParser.async(mode = AsyncParser.UnwrapArray)
 
@@ -128,7 +128,7 @@ def loop(st: Stream[String]): Either[ParseException, Unit] =
 loop(chunks)
 ```
 
-You can also call `jawn.Parser.async[J]` to use async parsing with an
+You can also call `Parser.async[J]` to use async parsing with an
 arbitrary data type (provided you also have an implicit `Facade[J]`).
 
 ### Supporting external ASTs with Jawn
@@ -157,7 +157,7 @@ Parser.parseFromChannel(ReadableByteChannel) → Try[J]
 Parser.parseFromByteBuffer(ByteBuffer) → Try[J]
 ```
 
-These methods parallel those provided by `jawn.Parser`.
+These methods parallel those provided by `org.typelevel.jawn.Parser`.
 
 For the following snippets, `XYZ` is one of (`argonaut`, `json4s`,
 `play`, `rojoma`, `rojoma-v3` or `spray`):
@@ -167,13 +167,15 @@ This is how you would include the subproject in build.sbt:
 ```scala
 resolvers += Resolver.sonatypeRepo("releases")
 
-libraryDependencies += "org.spire-math" %% jawn-"XYZ" % "0.13.0"
+libraryDependencies += "org.typelevel" %% jawn-"XYZ" % "0.14.0"
 ```
+
+(Note that prior to the 0.14.0 release, the group ID was `"org.spire-math"`.)
 
 This is an example of how you might use the parser into your code:
 
 ```scala
-import jawn.support.XYZ.Parser
+import org.typelevel.jawn.support.XYZ.Parser
 
 val myResult = Parser.parseFromString(myString)
 ```
@@ -191,7 +193,7 @@ snippet to your `build.sbt` file:
 ```scala
 resolvers += Resolver.sonatypeRepo("releases")
 
-libraryDependencies += "org.spire-math" %% "jawn-parser" % "0.13.0"
+libraryDependencies += "org.typelevel" %% "jawn-parser" % "0.14.0"
 ```
 
 To support your AST of choice, you'll want to define a `Facade[J]`

--- a/ast/src/main/scala/jawn/ast/JParser.scala
+++ b/ast/src/main/scala/jawn/ast/JParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package ast
 
 import java.io.File

--- a/ast/src/main/scala/jawn/ast/JValue.scala
+++ b/ast/src/main/scala/jawn/ast/JValue.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package ast
 
 import java.lang.Double.{isNaN, isInfinite}

--- a/ast/src/main/scala/jawn/ast/JawnFacade.scala
+++ b/ast/src/main/scala/jawn/ast/JawnFacade.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package ast
 
 import scala.collection.mutable

--- a/ast/src/main/scala/jawn/ast/Renderer.scala
+++ b/ast/src/main/scala/jawn/ast/Renderer.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package ast
 
 import scala.annotation.switch

--- a/ast/src/test/scala/jawn/ArbitraryUtil.scala
+++ b/ast/src/test/scala/jawn/ArbitraryUtil.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package ast
 
 import org.scalacheck._

--- a/ast/src/test/scala/jawn/AstTest.scala
+++ b/ast/src/test/scala/jawn/AstTest.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package ast
 
 import org.scalatest._

--- a/ast/src/test/scala/jawn/ParseCheck.scala
+++ b/ast/src/test/scala/jawn/ParseCheck.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package ast
 
 import org.scalatest._
@@ -11,7 +11,7 @@ import Arbitrary.arbitrary
 import scala.collection.mutable
 import scala.util.{Try, Success}
 
-import jawn.parser.TestUtil
+import org.typelevel.jawn.parser.TestUtil
 
 import ArbitraryUtil._
 

--- a/benchmark/src/main/scala/jawn/JmhBenchmarks.scala
+++ b/benchmark/src/main/scala/jawn/JmhBenchmarks.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package benchmark
 
 import java.io.{BufferedReader, File, FileInputStream, FileReader}

--- a/benchmark/src/main/scala/jawn/Parboiled.scala
+++ b/benchmark/src/main/scala/jawn/Parboiled.scala
@@ -1,4 +1,4 @@
-package jawn.benchmark
+package org.typelevel.jawn.benchmark
 
 /*
  * Copyright (C) 2009-2013 Mathias Doenitz, Alexander Myltsev

--- a/benchmark/src/main/scala/jawn/ParseLongBench.scala
+++ b/benchmark/src/main/scala/jawn/ParseLongBench.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package benchmark
 
 import java.io.{BufferedReader, File, FileInputStream, FileReader}
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.annotations._
 import scala.collection.mutable
 
-import jawn.util
+import org.typelevel.jawn.util
 
 case class Slice(s: String, begin: Int, limit: Int) extends CharSequence {
   val length: Int = limit - begin

--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ lazy val benchmarkVersion =
   "2.12.6"
 
 lazy val jawnSettings = Seq(
-  organization := "org.spire-math",
+  organization := "org.typelevel",
   scalaVersion := "2.12.6",
 
   //crossScalaVersions := allCrossVersions,
@@ -55,7 +55,7 @@ lazy val jawnSettings = Seq(
   },
 
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
-  homepage := Some(url("http://github.com/non/jawn")),
+  homepage := Some(url("http://github.com/typelevel/jawn")),
 
   // release stuff
   releaseCrossBuild := true,
@@ -73,8 +73,8 @@ lazy val jawnSettings = Seq(
   },
 
   scmInfo := Some(ScmInfo(
-    browseUrl = url("https://github.com/non/jawn"),
-    connection = "scm:git:git@github.com:non/jawn.git"
+    browseUrl = url("https://github.com/typelevel/jawn"),
+    connection = "scm:git:git@github.com:typelevel/jawn.git"
   )),
 
   developers += Developer(

--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import scala.annotation.{switch, tailrec}
 import scala.math.max

--- a/parser/src/main/scala/jawn/ByteBasedParser.scala
+++ b/parser/src/main/scala/jawn/ByteBasedParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import scala.annotation.{switch, tailrec}
 

--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import scala.annotation.{switch, tailrec}
 import java.nio.ByteBuffer

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import java.lang.Integer.{ bitCount, highestOneBit }
 import java.io.{File, FileInputStream}

--- a/parser/src/main/scala/jawn/CharBasedParser.scala
+++ b/parser/src/main/scala/jawn/CharBasedParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import scala.annotation.{switch, tailrec}
 

--- a/parser/src/main/scala/jawn/CharBuilder.scala
+++ b/parser/src/main/scala/jawn/CharBuilder.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 /**
  * CharBuilder is a specialized way to build Strings.

--- a/parser/src/main/scala/jawn/CharSequenceParser.scala
+++ b/parser/src/main/scala/jawn/CharSequenceParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 /**
  * Lazy character sequence parsing.

--- a/parser/src/main/scala/jawn/Facade.scala
+++ b/parser/src/main/scala/jawn/Facade.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 /**
  * Facade is a type class that describes how Jawn should construct

--- a/parser/src/main/scala/jawn/MutableFacade.scala
+++ b/parser/src/main/scala/jawn/MutableFacade.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import scala.collection.mutable
 

--- a/parser/src/main/scala/jawn/NullFacade.scala
+++ b/parser/src/main/scala/jawn/NullFacade.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 /**
  * NullFacade discards all JSON AST information.

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import java.io.File
 import java.nio.ByteBuffer

--- a/parser/src/main/scala/jawn/SimpleFacade.scala
+++ b/parser/src/main/scala/jawn/SimpleFacade.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import scala.collection.mutable
 

--- a/parser/src/main/scala/jawn/StringParser.scala
+++ b/parser/src/main/scala/jawn/StringParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 /**
  * Basic in-memory string parsing.

--- a/parser/src/main/scala/jawn/SupportParser.scala
+++ b/parser/src/main/scala/jawn/SupportParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import java.io.File
 import java.nio.ByteBuffer

--- a/parser/src/main/scala/jawn/SyncParser.scala
+++ b/parser/src/main/scala/jawn/SyncParser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import scala.annotation.{switch, tailrec}
 import scala.collection.mutable

--- a/parser/src/main/scala/jawn/Syntax.scala
+++ b/parser/src/main/scala/jawn/Syntax.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import java.io.File
 import java.nio.ByteBuffer

--- a/parser/src/test/scala/jawn/ChannelSpec.scala
+++ b/parser/src/test/scala/jawn/ChannelSpec.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package parser
 
 import org.scalatest._

--- a/parser/src/test/scala/jawn/CharBuilderSpec.scala
+++ b/parser/src/test/scala/jawn/CharBuilderSpec.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 import org.scalatest._
 import org.scalatest.prop._

--- a/parser/src/test/scala/jawn/JNumIndexCheck.scala
+++ b/parser/src/test/scala/jawn/JNumIndexCheck.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package parser
 
 import java.nio.ByteBuffer

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package parser
 
 import org.scalatest._

--- a/parser/src/test/scala/jawn/TestUtil.scala
+++ b/parser/src/test/scala/jawn/TestUtil.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package parser
 
 import java.io._

--- a/support/argonaut/src/main/scala/Parser.scala
+++ b/support/argonaut/src/main/scala/Parser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package support.argonaut
 
 import scala.collection.mutable

--- a/support/argonaut/src/test/scala/ParserSpec.scala
+++ b/support/argonaut/src/test/scala/ParserSpec.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package support.argonaut
 
 import argonaut._
@@ -26,12 +26,12 @@ object ParserSpec {
 
 class ParserSpec extends FlatSpec with Matchers with Checkers {
   import ParserSpec._
-  import jawn.support.argonaut.Parser.facade
+  import org.typelevel.jawn.support.argonaut.Parser.facade
 
   "The Argonaut support Parser" should "correctly marshal case classes with Long values" in {
     check { (e: Example) =>
       val jsonString: String = exampleCodecJson.encode(e).nospaces
-      val json: Try[Json] = jawn.Parser.parseFromString(jsonString)
+      val json: Try[Json] = org.typelevel.jawn.Parser.parseFromString(jsonString)
       exampleCodecJson.decodeJson(json.get).toOption match {
         case None => fail()
         case Some(example) => example == e

--- a/support/json4s/src/main/scala/Parser.scala
+++ b/support/json4s/src/main/scala/Parser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package support.json4s
 
 import scala.collection.mutable

--- a/support/play/src/main/scala/Parser.scala
+++ b/support/play/src/main/scala/Parser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package support.play
 
 import play.api.libs.json._

--- a/support/rojoma-v3/src/main/scala/Parser.scala
+++ b/support/rojoma-v3/src/main/scala/Parser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package support.rojoma.v3
 
 import scala.collection.mutable

--- a/support/rojoma/src/main/scala/Parser.scala
+++ b/support/rojoma/src/main/scala/Parser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package support.rojoma
 
 import scala.collection.mutable

--- a/support/spray/src/main/scala/Parser.scala
+++ b/support/spray/src/main/scala/Parser.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package support.spray
 
 import spray.json._

--- a/util/src/main/scala/jawn/util/InvalidLong.scala
+++ b/util/src/main/scala/jawn/util/InvalidLong.scala
@@ -1,4 +1,4 @@
-package jawn.util
+package org.typelevel.jawn.util
 
 class InvalidLong(s: String) extends NumberFormatException(s"For input string '$s'")
 

--- a/util/src/main/scala/jawn/util/Slice.scala
+++ b/util/src/main/scala/jawn/util/Slice.scala
@@ -1,4 +1,4 @@
-package jawn.util
+package org.typelevel.jawn.util
 
 /**
  * Character sequence representing a lazily-calculated substring.

--- a/util/src/main/scala/jawn/util/package.scala
+++ b/util/src/main/scala/jawn/util/package.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 
 package object util {
 

--- a/util/src/test/scala/jawn/util/ParseLongCheck.scala
+++ b/util/src/test/scala/jawn/util/ParseLongCheck.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package util
 
 import org.scalatest._

--- a/util/src/test/scala/jawn/util/SliceCheck.scala
+++ b/util/src/test/scala/jawn/util/SliceCheck.scala
@@ -1,4 +1,4 @@
-package jawn
+package org.typelevel.jawn
 package util
 
 import org.scalatest._


### PR DESCRIPTION
See #126 and [the membership proposal](https://github.com/typelevel/general/issues/92). As @larsrh notes, the project needs to be protected by a code of contact, and I've added a note to the README. I've chosen the Typelevel CoC, but could change it to the Scala CoC.

I've added the `org.typelevel` prefix to all packages, as requested by @dwijnand in #126. This isn't strictly necessary for the move, but it should help make the transition a little easier for adopters, and the new package naming seems reasonable to me, anyway.