### PR TITLE
Fix Slice error-detection inadequacies.

### DIFF
--- a/util/src/main/scala/jawn/util/Slice.scala
+++ b/util/src/main/scala/jawn/util/Slice.scala
@@ -47,7 +47,7 @@ final class Slice private[jawn] (s: String, start: Int, limit: Int) extends Char
     val start2 = start + i
     val limit2 = start + j
     if (start2 > limit) throw new StringIndexOutOfBoundsException(s"i ($i) should be <= limit (${limit - start})")
-    if (limit2 > limit) throw new StringIndexOutOfBoundsException(s"i ($i) should be <= limit (${limit - start})")
+    if (limit2 > limit) throw new StringIndexOutOfBoundsException(s"j ($j) should be <= limit (${limit - start})")
     Slice.unsafe(s, start2, limit2)
   }
 

--- a/util/src/main/scala/jawn/util/Slice.scala
+++ b/util/src/main/scala/jawn/util/Slice.scala
@@ -41,8 +41,15 @@ final class Slice private[jawn] (s: String, start: Int, limit: Int) extends Char
     if (i < 0 || length <= i) throw new StringIndexOutOfBoundsException(s"index out of range: $i")
     else s.charAt(start + i)
 
-  def subSequence(i: Int, j: Int): Slice =
-    Slice(s, start + i, start + j)
+  def subSequence(i: Int, j: Int): Slice = {
+    if (i < 0) throw new StringIndexOutOfBoundsException(s"i ($i) should be >= 0")
+    if (j < i) throw new StringIndexOutOfBoundsException(s"j ($j) should be >= i ($i)")
+    val start2 = start + i
+    val limit2 = start + j
+    if (start2 > limit) throw new StringIndexOutOfBoundsException(s"i ($i) should be <= limit (${limit - start})")
+    if (limit2 > limit) throw new StringIndexOutOfBoundsException(s"i ($i) should be <= limit (${limit - start})")
+    Slice.unsafe(s, start2, limit2)
+  }
 
   override def toString: String =
     s.substring(start, limit)

--- a/util/src/test/scala/jawn/util/SliceCheck.scala
+++ b/util/src/test/scala/jawn/util/SliceCheck.scala
@@ -11,6 +11,10 @@ import scala.util._
 
 class SliceCheck extends PropSpec with Matchers with PropertyChecks {
 
+  // crank this up to stress-test the Slice class.
+  implicit override val generatorDrivenConfig =
+    PropertyCheckConfiguration(minSuccessful = 100)
+
   val genSlice: Gen[Slice] = {
     val g = arbitrary[String]
     def c(start: Int, end: Int): Gen[Int] =


### PR DESCRIPTION
Previously Slice didn't catch all cases where .subSequence could fail.
Broadly-speaking, these are cases where a small slice gets "expanded" through
use of negative or large values, which exceed the slice boundaries but are
still valid in the underlying String.

I've tightened up the error-checking here, and run failing properties through
100K evaluations, so I feel more confident we're doing the right thing.

Note that Slice isn't actually used in Jawn, so this bug would mostly affect
downstream folks using Slice themselves (and relying on Slice to detect
indexing bugs).

cc @eed3si9n 