### PR TITLE
Add back language: scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 dist: xenial
 group: stable
 
+language: scala
 jdk: openjdk8
 
 apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,9 @@ apt:
   packages:
     - openjdk8
 
-# workaround https://github.com/travis-ci/travis-ci/issues/9816
-addons:
-  apt:
-    sources:
-      - sourceline: "deb https://dl.bintray.com/sbt/debian /"
-        key_url: "https://bintray.com/user/downloadSubjectPublicKey?username=sbt"
-    packages:
-      - sbt=1.2.7
-
 before_install:
   - PATH=$(echo "$PATH" | sed -e 's/:\/usr\/local\/lib\/jvm\/openjdk11\/bin//')
   - JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64
-  - PATH=/usr/bin:$PATH
-  - export JAVA_OPTS="-server -Dfile.encoding=UTF-8 -Xss2M -Xms1024M -Xmx1024M -XX:ReservedCodeCacheSize=128m"
-  - export SBT_OPTS=
 
 script:
   - sbt "+ test"


### PR DESCRIPTION
This fixes a mistake I made in #117.

1. By mistake I removed `language: scala` in the first commit - 0923c8c75bcae996471e10c387b9cbb0a3c95de1
2. This made Travis CI revert to Ruby build environment, which contains an old version of sbt-extras.
3. To workaround it I installed the official `sbt` distribution - 97f3eed121e22e6cc3a4b62e5ae62fb0bc1994b4

This reverts 97f3eed121e22e6cc3a4b62e5ae62fb0bc1994b4, and adds back `language: scala`.

