### PR TITLE
Fix error location reporting.

### DIFF
--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -93,6 +93,22 @@ final class AsyncParser[J] protected[jawn] (
   final def absorb(s: String)(implicit facade: RawFacade[J]): Either[ParseException, collection.Seq[J]] =
     absorb(ByteBuffer.wrap(s.getBytes(utf8)))
 
+  final def finalAbsorb(buf: ByteBuffer)(implicit facade: RawFacade[J]): Either[ParseException, collection.Seq[J]] =
+    absorb(buf)(facade) match {
+      case Right(xs) =>
+        finish()(facade) match {
+          case Right(ys) => Right(xs ++ ys)
+          case left1 @ Left(_) => left1
+        }
+      case left0 @ Left(_) => left0
+    }
+
+  final def finalAbsorb(bytes: Array[Byte])(implicit facade: RawFacade[J]): Either[ParseException, collection.Seq[J]] =
+    finalAbsorb(ByteBuffer.wrap(bytes))
+
+  final def finalAbsorb(s: String)(implicit facade: RawFacade[J]): Either[ParseException, collection.Seq[J]] =
+    finalAbsorb(ByteBuffer.wrap(s.getBytes(utf8)))
+
   final def finish()(implicit facade: RawFacade[J]): Either[ParseException, collection.Seq[J]] = {
     done = true
     churn()

--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -18,10 +18,11 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
   private[this] final val limit = src.limit() - start
 
   private[this] var lineState = 0
+  private[this] var offset = 0
   protected[this] def line(): Int = lineState
 
-  protected[this] final def newline(i: Int): Unit = { lineState += 1 }
-  protected[this] final def column(i: Int) = i
+  protected[this] final def newline(i: Int): Unit = { lineState += 1; offset = i + 1 }
+  protected[this] final def column(i: Int) = i - offset
 
   protected[this] final def close(): Unit = { src.position(src.limit) }
   protected[this] final def reset(i: Int): Int = i

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -66,7 +66,7 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
 
   var line = 0
   private var pos = 0
-  protected[this] final def newline(i: Int): Unit = { line += 1; pos = i }
+  protected[this] final def newline(i: Int): Unit = { line += 1; pos = i + 1 }
   protected[this] final def column(i: Int): Int = i - pos
 
   protected[this] final def close(): Unit = ch.close()

--- a/parser/src/main/scala/jawn/CharSequenceParser.scala
+++ b/parser/src/main/scala/jawn/CharSequenceParser.scala
@@ -7,8 +7,9 @@ package org.typelevel.jawn
  */
 private[jawn] final class CharSequenceParser[J](cs: CharSequence) extends SyncParser[J] with CharBasedParser[J] {
   var line = 0
-  final def column(i: Int) = i
-  final def newline(i: Int): Unit = { line += 1 }
+  var offset = 0
+  final def column(i: Int) = i - offset
+  final def newline(i: Int): Unit = { line += 1; offset = i + 1 }
   final def reset(i: Int): Int = i
   final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]): Unit = ()
   final def at(i: Int): Char = cs.charAt(i)

--- a/parser/src/main/scala/jawn/StringParser.scala
+++ b/parser/src/main/scala/jawn/StringParser.scala
@@ -14,8 +14,9 @@ package org.typelevel.jawn
  */
 private[jawn] final class StringParser[J](s: String) extends SyncParser[J] with CharBasedParser[J] {
   var line = 0
-  final def column(i: Int) = i
-  final def newline(i: Int): Unit = { line += 1 }
+  var offset = 0
+  final def column(i: Int) = i - offset
+  final def newline(i: Int): Unit = { line += 1; offset = i + 1 }
   final def reset(i: Int): Int = i
   final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]): Unit = ()
   final def at(i: Int): Char = s.charAt(i)

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -203,7 +203,7 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
         case otherwise => fail(s"expected Failure(ParseException), got $otherwise")
       }
 
-    def extract2(e: Either[ParseException, Seq[Unit]]): Unit =
+    def extract2(e: Either[ParseException, collection.Seq[Unit]]): Unit =
       e match {
         case Left(p) => assertLoc(p)
         case right => fail(s"expected Left(ParseException), got $right")

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -10,6 +10,8 @@ import Arbitrary.arbitrary
 
 import scala.util.{Try, Success, Failure}
 
+import java.nio.ByteBuffer
+
 class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
 
   sealed trait J {
@@ -59,8 +61,6 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
   implicit lazy val arbJValue: Arbitrary[J] =
     Arbitrary(jvalue(0))
 
-  import java.nio.ByteBuffer
-
   def isValidSyntax(s: String): Boolean = {
     val cs = java.nio.CharBuffer.wrap(s.toCharArray)
     val r0 = Parser.parseFromCharSequence(cs)(NullFacade).isSuccess
@@ -75,12 +75,8 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
     }
 
     val async = AsyncParser[Unit](AsyncParser.SingleValue)
-    val r3 = async.absorb(s)(NullFacade) match {
-      case Right(xs) =>
-        async.finish()(NullFacade) match {
-          case Right(ys) => (xs.size + ys.size) == 1
-          case Left(_) => false
-        }
+    val r3 = async.finalAbsorb(s)(NullFacade) match {
+      case Right(xs) => xs.size == 1
       case Left(_) => false
     }
 
@@ -184,4 +180,44 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
   property("stack-safety 8") {
     isStackSafe(s"false${S},${S}false") shouldBe Success(false)
   }
+
+  def testErrorLoc(json: String, line: Int, col: Int): Unit = {
+    import java.io.ByteArrayInputStream
+    import java.nio.channels.{Channels, ReadableByteChannel}
+    isValidSyntax(json) shouldBe false
+
+    def ch(s: String): ReadableByteChannel =
+      Channels.newChannel(new ByteArrayInputStream(s.getBytes))
+
+    def bb(s: String): ByteBuffer =
+      ByteBuffer.wrap(s.getBytes("UTF-8"))
+
+    def assertLoc(p: ParseException): Unit = {
+      p.line shouldBe line
+      p.col shouldBe col
+    }
+
+    def extract1(t: Try[Unit]): Unit =
+      t match {
+        case Failure(p @ ParseException(_, _, _, _)) => assertLoc(p)
+        case otherwise => fail(s"expected Failure(ParseException), got $otherwise")
+      }
+
+    def extract2(e: Either[ParseException, Seq[Unit]]): Unit =
+      e match {
+        case Left(p) => assertLoc(p)
+        case right => fail(s"expected Left(ParseException), got $right")
+      }
+
+    extract1(Parser.parseFromString(json)(NullFacade))
+    extract1(Parser.parseFromCharSequence(json)(NullFacade))
+    extract1(Parser.parseFromChannel(ch(json))(NullFacade))
+    extract1(Parser.parseFromByteBuffer(bb(json))(NullFacade))
+    extract2(Parser.async(AsyncParser.UnwrapArray)(NullFacade).finalAbsorb(json)(NullFacade))
+  }
+
+  property("error location 1") { testErrorLoc("[1, 2,\nx3]", 2, 1) }
+  property("error location 2") { testErrorLoc("[1, 2,    \n   x3]", 2, 4) }
+  property("error location 3") { testErrorLoc("[1, 2,\n\n\n\n\nx3]", 6, 1) }
+  property("error location 4") { testErrorLoc("[1, 2,\n\n3,\n4,\n\n x3]", 6, 2) }
 }

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -187,7 +187,7 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
     isValidSyntax(json) shouldBe false
 
     def ch(s: String): ReadableByteChannel =
-      Channels.newChannel(new ByteArrayInputStream(s.getBytes))
+      Channels.newChannel(new ByteArrayInputStream(s.getBytes("UTF-8")))
 
     def bb(s: String): ByteBuffer =
       ByteBuffer.wrap(s.getBytes("UTF-8"))


### PR DESCRIPTION
Previously Jawn was pretty sloppy about keeping track of the current column
location. Line numbers were correct, but column numbers were often wrong.

This commit fixes the problem for all the concrete parsers provided and ensures
they all return the same error locations.

Fixes #119 