### PR TITLE
Fix #143

### DIFF
--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -375,7 +375,7 @@ abstract class Parser[J] {
       case 'n' => (parseNull(i), i + 4)
 
       // invalid
-      case _ => die(i, "expected json value", 1)
+      case _ => die(i, "expected json value")
     }
 
   /**

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -99,7 +99,7 @@ abstract class Parser[J] {
    * a workaround; it is not optimized or robust against invalid input and
    * should not be used outside of the context of `die`.
    */
-  private[this] def safeAt(i: Int, j: Int): CharSequence =
+  @tailrec private[this] def safeAt(i: Int, j: Int): CharSequence =
     if (j <= i) "" else {
       try at(i, j) catch {
         case _: Exception =>

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -375,7 +375,7 @@ abstract class Parser[J] {
       case 'n' => (parseNull(i), i + 4)
 
       // invalid
-      case _ => die(i, "expected json value")
+      case _ => die(i, "expected json value", 1)
     }
 
   /**

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -222,8 +222,15 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
   property("error location 3") { testErrorLoc("[1, 2,\n\n\n\n\nx3]", 6, 1) }
   property("error location 4") { testErrorLoc("[1, 2,\n\n3,\n4,\n\n x3]", 6, 2) }
 
-  property("absorb should fail fast on }") {
-    val async = AsyncParser[Unit](AsyncParser.UnwrapArray)
-    async.absorb("}")(NullFacade).isLeft shouldBe true
+  property("absorb should fail fast on bad inputs") {
+    def absorbFails(in: String): Boolean = {
+      val async = AsyncParser[Unit](AsyncParser.UnwrapArray)
+      async.absorb("}")(NullFacade).isLeft
+    }
+
+    val badInputs = Seq("}", "fälse", "n0ll", "try", "0x", "0.x", "0ex", "[1; 2]", "{\"a\"; 1}", "{1: 2}")
+    badInputs.foreach { input =>
+      absorbFails(input) shouldBe true
+    }
   }
 }

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -100,6 +100,7 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
   }
 
   property("empty is invalid") { isValidSyntax("") shouldBe false }
+  property("} is invalid") { isValidSyntax("}") shouldBe false }
 
   property("literal TAB is invalid") { isValidSyntax(qs("\t")) shouldBe false }
   property("literal NL is invalid") { isValidSyntax(qs("\n")) shouldBe false }
@@ -220,4 +221,9 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
   property("error location 2") { testErrorLoc("[1, 2,    \n   x3]", 2, 4) }
   property("error location 3") { testErrorLoc("[1, 2,\n\n\n\n\nx3]", 6, 1) }
   property("error location 4") { testErrorLoc("[1, 2,\n\n3,\n4,\n\n x3]", 6, 2) }
+
+  property("absorb should fail fast on }") {
+    val async = AsyncParser[Unit](AsyncParser.UnwrapArray)
+    async.absorb("}")(NullFacade).isLeft shouldBe true
+  }
 }


### PR DESCRIPTION
This is a funny one. The problem is that the new error message stuff from #129 calls `at(i, j)` with out-of-bounds arguments on `AsyncParser`, which throws an `AsyncException` instead of a `ParseException`, which means the `absorb` call isn't treated as a failure.

My feeling is that we're going to keep seeing problems introduced by #129 for a while, starting with #142, which I'm hoping to get to next.

r? @BenFradet @non 