### PR TITLE
Fix #142

### DIFF
--- a/parser/src/main/scala/jawn/ByteBasedParser.scala
+++ b/parser/src/main/scala/jawn/ByteBasedParser.scala
@@ -29,7 +29,7 @@ trait ByteBasedParser[J] extends Parser[J] {
     var j = i
     var c: Int = byte(j) & 0xff
     while (c != 34) {
-      if (c < 32) return die(j, s"control char ($c) in string")
+      if (c < 32) return die(j, s"control char ($c) in string", 1)
       if (c == 92) return -1
       j += 1
       c = byte(j) & 0xff
@@ -76,10 +76,10 @@ trait ByteBasedParser[J] extends Parser[J] {
             sb.append(descape(jj, at(jj, jj + 4)))
             j += 6
 
-          case c => die(j, s"invalid escape sequence (\\${c.toChar})")
+          case c => die(j, s"invalid escape sequence (\\${c.toChar})", 1)
         }
       } else if (c < 32) {
-        die(j, s"control char ($c) in string")
+        die(j, s"control char ($c) in string", 1)
       } else if (c < 128) {
         // 1-byte UTF-8 sequence
         sb.append(c.toChar)

--- a/parser/src/main/scala/jawn/CharBasedParser.scala
+++ b/parser/src/main/scala/jawn/CharBasedParser.scala
@@ -26,7 +26,7 @@ trait CharBasedParser[J] extends Parser[J] {
     var j = i
     var c = at(j)
     while (c != '"') {
-      if (c < ' ') return die(j, s"control char (${c.toInt}) in string")
+      if (c < ' ') return die(j, s"control char (${c.toInt}) in string", 1)
       if (c == '\\') return -1
       j += 1
       c = at(j)
@@ -44,7 +44,7 @@ trait CharBasedParser[J] extends Parser[J] {
     var c = at(j)
     while (c != '"') {
       if (c < ' ') {
-        die(j, s"control char (${c.toInt}) in string")
+        die(j, s"control char (${c.toInt}) in string", 1)
       } else if (c == '\\') {
         (at(j + 1): @switch) match {
           case 'b' => { sb.append('\b'); j += 2 }
@@ -63,7 +63,7 @@ trait CharBasedParser[J] extends Parser[J] {
             sb.append(descape(jj, at(jj, jj + 4)))
             j += 6
 
-          case c => die(j, s"illegal escape sequence (\\$c)")
+          case c => die(j, s"illegal escape sequence (\\$c)", 1)
         }
       } else {
         // this case is for "normal" code points that are just one Char.

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -220,4 +220,10 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
   property("error location 2") { testErrorLoc("[1, 2,    \n   x3]", 2, 4) }
   property("error location 3") { testErrorLoc("[1, 2,\n\n\n\n\nx3]", 6, 1) }
   property("error location 4") { testErrorLoc("[1, 2,\n\n3,\n4,\n\n x3]", 6, 2) }
+
+  property("no extra \" in error message") {
+    val result = Parser.parseFromString("\"\u0000\"")(NullFacade)
+    val expected = "control char (0) in string got '\u0000...' (line 1, column 2)"
+    result.failed.get.getMessage shouldBe expected
+  }
 }


### PR DESCRIPTION
Similar to #143, just limits the error message context so we don't end up with the closing quotation mark.

r? @non 