### PR TITLE
Remove old versions, housekeeping, etc.

### DIFF
--- a/ast/src/test/scala/jawn/ArbitraryUtil.scala
+++ b/ast/src/test/scala/jawn/ArbitraryUtil.scala
@@ -1,8 +1,8 @@
 package org.typelevel.jawn
 package ast
 
-import org.scalacheck._
-import Gen._
+import org.scalacheck.{Arbitrary, Gen}
+
 import Arbitrary.arbitrary
 
 object ArbitraryUtil {

--- a/ast/src/test/scala/jawn/AstTest.scala
+++ b/ast/src/test/scala/jawn/AstTest.scala
@@ -1,79 +1,74 @@
 package org.typelevel.jawn
 package ast
 
-import org.scalatest._
-import org.scalatest.prop._
-
+import claimant.Claim
+import org.scalacheck.{Prop, Properties}
 import scala.collection.mutable
 import scala.util.{Try, Success}
 
 import ArbitraryUtil._
+import Prop.forAll
 
-class AstTest extends PropSpec with Matchers with PropertyChecks {
+class AstTest extends Properties("AstTest") {
 
-  property("calling .get never crashes") {
+  property("calling .get never crashes") =
     forAll { (v: JValue, s: String, i: Int) =>
-      Try(v.get(i).get(s)).isSuccess shouldBe true
-      Try(v.get(s).get(i)).isSuccess shouldBe true
-      Try(v.get(i).get(i)).isSuccess shouldBe true
-      Try(v.get(s).get(s)).isSuccess shouldBe true
+      Claim(
+        Try(v.get(i).get(s)).isSuccess &&
+          Try(v.get(s).get(i)).isSuccess &&
+          Try(v.get(i).get(i)).isSuccess &&
+          Try(v.get(s).get(s)).isSuccess)
     }
-  }
 
-  property(".getX and .asX agree") {
+  property(".getX and .asX agree") =
     forAll { (v: JValue) =>
-      v.getBoolean shouldBe Try(v.asBoolean).toOption
-      v.getString shouldBe Try(v.asString).toOption
-      v.getInt shouldBe Try(v.asInt).toOption
-      v.getLong shouldBe Try(v.asLong).toOption
-      v.getDouble shouldBe Try(v.asDouble).toOption
-      v.getBigInt shouldBe Try(v.asBigInt).toOption
-      v.getBigDecimal shouldBe Try(v.asBigDecimal).toOption
+      Claim(
+        v.getBoolean == Try(v.asBoolean).toOption &&
+          v.getString == Try(v.asString).toOption &&
+          v.getInt == Try(v.asInt).toOption &&
+          v.getLong == Try(v.asLong).toOption &&
+          v.getDouble == Try(v.asDouble).toOption &&
+          v.getBigInt == Try(v.asBigInt).toOption &&
+          v.getBigDecimal == Try(v.asBigDecimal).toOption)
     }
-  }
 
-  property(".getBoolean") {
-    forAll((b: Boolean) => JBool(b).getBoolean shouldBe Some(b))
-  }
+  property(".getBoolean") =
+    forAll((b: Boolean) => Claim(JBool(b).getBoolean == Some(b)))
 
-  property(".getString") {
-    forAll((s: String) => JString(s).getString shouldBe Some(s))
-  }
+  property(".getString") =
+    forAll((s: String) => Claim(JString(s).getString == Some(s)))
 
-  property(".getInt") {
+  property(".getInt") =
     forAll { (n: Int) =>
-      JNum(n).getInt shouldBe Some(n)
-      JParser.parseUnsafe(n.toString).getInt shouldBe Some(n)
+      Claim(JNum(n).getInt == Some(n) &&
+        JParser.parseUnsafe(n.toString).getInt == Some(n))
     }
-  }
 
-  property(".getLong") {
+  property(".getLong") =
     forAll { (n: Long) =>
-      JNum(n).getLong shouldBe Some(n)
-      JParser.parseUnsafe(n.toString).getLong shouldBe Some(n)
+      Claim(JNum(n).getLong == Some(n) &&
+        JParser.parseUnsafe(n.toString).getLong == Some(n))
     }
-  }
 
-  property(".getDouble") {
+  property(".getDouble") =
     forAll { (n: Double) =>
-      JNum(n).getDouble shouldBe Some(n)
-      JParser.parseUnsafe(n.toString).getDouble shouldBe Some(n)
+      Claim(JNum(n).getDouble == Some(n) &&
+        JParser.parseUnsafe(n.toString).getDouble == Some(n))
     }
-  }
 
-  property(".getBigInt") {
+  property(".getBigInt") =
     forAll { (n: BigInt) =>
-      JNum(n.toString).getBigInt shouldBe Some(n)
-      JParser.parseUnsafe(n.toString).getBigInt shouldBe Some(n)
+      Claim(JNum(n.toString).getBigInt == Some(n) &&
+        JParser.parseUnsafe(n.toString).getBigInt == Some(n))
     }
-  }
 
-  property(".getBigDecimal") {
+  property(".getBigDecimal") =
     forAll { (n: BigDecimal) =>
       if (Try(BigDecimal(n.toString)) == Success(n)) {
-        JNum(n.toString).getBigDecimal shouldBe Some(n)
-        JParser.parseUnsafe(n.toString).getBigDecimal shouldBe Some(n)
+        Claim(JNum(n.toString).getBigDecimal == Some(n) &&
+          JParser.parseUnsafe(n.toString).getBigDecimal == Some(n))
+      } else {
+        Claim(true)
       }
     }
-  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import ReleaseTransformations._
 
 lazy val previousJawnVersion = "0.14.0"
 
-lazy val scala210 = "2.10.7"
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.8"
 lazy val scala213 = "2.13.0-M5"
@@ -24,9 +23,9 @@ ThisBuild / developers += Developer(
 )
 
 lazy val stableCrossVersions =
-  Seq(scala210, scala211, scala212)
+  Seq(scala211, scala212)
 
-// we'll support 2.13.0-M1 soon but not yet
+// we'll support 2.13.0-M5 soon but not yet
 lazy val allCrossVersions =
   stableCrossVersions :+ scala213
 
@@ -43,17 +42,9 @@ lazy val jawnSettings = Seq(
 
   Test / fork := true,
 
-  libraryDependencies += {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, v)) if v < 13 =>
-        "org.scalatest" %% "scalatest" % "3.0.5" % Test
-      case _ =>
-        "org.scalatest" %% "scalatest" % "3.0.6-SNAP5" % Test
-    }
-  },
-
   libraryDependencies ++=
     "org.scalacheck" %% "scalacheck" % "1.14.0" % Test ::
+    "org.spire-math" %% "claimant" % "0.0.4" % Test ::
     Nil,
 
   scalacOptions ++=
@@ -158,17 +149,7 @@ lazy val supportJson4s = support("json4s")
 
 lazy val supportPlay = support("play")
   .settings(crossScalaVersions := allCrossVersions)
-  .settings(libraryDependencies += {
-    "com.typesafe.play" %% "play-json" % (
-      CrossVersion.partialVersion(scalaVersion.value) match {
-        case Some((2, 10)) =>
-          // play-json 2.7.x does not support Scala 2.10
-          "2.6.13"
-        case _ =>
-          "2.7.0"
-      }
-    )
-  })
+  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.7.0")
 
 lazy val supportRojoma = support("rojoma")
   .settings(crossScalaVersions := stableCrossVersions)

--- a/parser/src/test/scala/jawn/ChannelSpec.scala
+++ b/parser/src/test/scala/jawn/ChannelSpec.scala
@@ -1,25 +1,27 @@
 package org.typelevel.jawn
 package parser
 
-import org.scalatest._
-
+import claimant.Claim
 import java.nio.channels.ByteChannel
+import org.scalacheck.Properties
 import scala.util.Success
 
-class ChannelSpec extends PropSpec with Matchers {
+class ChannelSpec extends Properties("ChannelSpec") {
 
-  property("large strings in files are ok") {
+  property("large strings in files are ok") = {
     val M = 1000000
     val q = "\""
     val big = q + ("x" * (40 * M)) + q
     val bigEscaped = q + ("\\\\" * (20 * M)) + q
 
-    TestUtil.withTemp(big) { t =>
-      Parser.parseFromFile(t)(NullFacade).isSuccess shouldBe true
+    val ok1 = TestUtil.withTemp(big) { t =>
+      Parser.parseFromFile(t)(NullFacade).isSuccess
     }
 
-    TestUtil.withTemp(bigEscaped) { t =>
-      Parser.parseFromFile(t)(NullFacade).isSuccess shouldBe true
+    val ok2 = TestUtil.withTemp(bigEscaped) { t =>
+      Parser.parseFromFile(t)(NullFacade).isSuccess
     }
+
+    Claim(ok1 && ok2)
   }
 }

--- a/parser/src/test/scala/jawn/CharBuilderSpec.scala
+++ b/parser/src/test/scala/jawn/CharBuilderSpec.scala
@@ -1,23 +1,22 @@
 package org.typelevel.jawn
 
-import org.scalatest._
-import org.scalatest.prop._
+import claimant.Claim
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
 
-class CharBuilderSpec extends PropSpec with Matchers with PropertyChecks {
+class CharBuilderSpec extends Properties("CharBuilderSpec") {
 
-  property("append") {
+  property("append") =
     forAll { xs: List[Char] =>
       val builder = new CharBuilder
       xs.foreach(builder.append)
-      builder.makeString shouldBe xs.mkString
+      Claim(builder.makeString == xs.mkString)
     }
-  }
 
-  property("extend") {
+  property("extend") =
     forAll { xs: List[String] =>
       val builder = new CharBuilder
       xs.foreach(builder.extend)
-      builder.makeString shouldBe xs.mkString
+      Claim(builder.makeString == xs.mkString)
     }
-  }
 }

--- a/parser/src/test/scala/jawn/JNumIndexCheck.scala
+++ b/parser/src/test/scala/jawn/JNumIndexCheck.scala
@@ -1,12 +1,14 @@
 package org.typelevel.jawn
 package parser
 
+import claimant.Claim
 import java.nio.ByteBuffer
-import org.scalatest.{Matchers, PropSpec}
-import org.scalatest.prop.PropertyChecks
+import org.scalacheck.Properties
+import org.scalacheck.Prop.forAll
 import scala.util.Success
 
-class JNumIndexCheck extends PropSpec with Matchers with PropertyChecks {
+class JNumIndexCheck extends Properties("JNumIndexCheck") {
+
   object JNumIndexCheckFacade extends Facade[Boolean] {
     class JNumIndexCheckContext(val isObj: Boolean) extends FContext[Boolean] {
       var failed = false
@@ -34,48 +36,42 @@ class JNumIndexCheck extends PropSpec with Matchers with PropertyChecks {
     def jstring(s: CharSequence): Boolean = true
   }
 
-  property("jnum provides the correct indices with parseFromString") {
+  property("jnum provides the correct indices with parseFromString") =
     forAll { (value: BigDecimal) =>
       val json = s"""{ "num": ${value.toString} }"""
-      Parser.parseFromString(json)(JNumIndexCheckFacade) shouldBe Success(true)
+      Claim(Parser.parseFromString(json)(JNumIndexCheckFacade) == Success(true))
     }
-  }
 
-  property("jnum provides the correct indices with parseFromByteBuffer") {
+  property("jnum provides the correct indices with parseFromByteBuffer") =
     forAll { (value: BigDecimal) =>
       val json = s"""{ "num": ${value.toString} }"""
       val bb = ByteBuffer.wrap(json.getBytes("UTF-8"))
-      Parser.parseFromByteBuffer(bb)(JNumIndexCheckFacade) shouldBe Success(true)
+      Claim(Parser.parseFromByteBuffer(bb)(JNumIndexCheckFacade) == Success(true))
     }
-  }
 
-  property("jnum provides the correct indices with parseFromFile") {
+  property("jnum provides the correct indices with parseFromFile") =
     forAll { (value: BigDecimal) =>
       val json = s"""{ "num": ${value.toString} }"""
       TestUtil.withTemp(json) { t =>
-        Parser.parseFromFile(t)(JNumIndexCheckFacade) shouldBe Success(true)
+        Claim(Parser.parseFromFile(t)(JNumIndexCheckFacade) == Success(true))
       }
     }
-  }
 
-  property("jnum provides the correct indices at the top level with parseFromString") {
+  property("jnum provides the correct indices at the top level with parseFromString") =
     forAll { (value: BigDecimal) =>
-      Parser.parseFromString(value.toString)(JNumIndexCheckFacade) shouldBe Success(true)
+      Claim(Parser.parseFromString(value.toString)(JNumIndexCheckFacade) == Success(true))
     }
-  }
 
-  property("jnum provides the correct indices at the top level with parseFromByteBuffer") {
+  property("jnum provides the correct indices at the top level with parseFromByteBuffer") =
     forAll { (value: BigDecimal) =>
       val bb = ByteBuffer.wrap(value.toString.getBytes("UTF-8"))
-      Parser.parseFromByteBuffer(bb)(JNumIndexCheckFacade) shouldBe Success(true)
+      Claim(Parser.parseFromByteBuffer(bb)(JNumIndexCheckFacade) == Success(true))
     }
-  }
 
-  property("jnum provides the correct indices at the top level with parseFromFile") {
+  property("jnum provides the correct indices at the top level with parseFromFile") =
     forAll { (value: BigDecimal) =>
       TestUtil.withTemp(value.toString) { t =>
-        Parser.parseFromFile(t)(JNumIndexCheckFacade) shouldBe Success(true)
+        Claim(Parser.parseFromFile(t)(JNumIndexCheckFacade) == Success(true))
       }
     }
-  }
 }

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -1,18 +1,15 @@
 package org.typelevel.jawn
 package parser
 
-import org.scalatest._
-import prop._
-import org.scalacheck.Arbitrary._
-import org.scalacheck._
-import Gen._
-import Arbitrary.arbitrary
-
+import claimant.Claim
+import java.nio.ByteBuffer
+import org.scalacheck.{Arbitrary, Gen, Prop, Properties}
 import scala.util.{Try, Success, Failure}
 
-import java.nio.ByteBuffer
+import Arbitrary.arbitrary
+import Prop.forAll
 
-class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
+class SyntaxCheck extends Properties("SyntaxCheck") {
 
   sealed trait J {
     def build: String = this match {
@@ -83,62 +80,61 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
     if (r1 == r3) r1 else sys.error(s"Sync/Async parsing disagree($r1, $r3): $s")
   }
 
-  property("syntax-checking") {
-    forAll { (j: J) => isValidSyntax(j.build) shouldBe true }
-  }
+  property("syntax-checking") =
+    forAll { (j: J) => isValidSyntax(j.build)  }
 
   def qs(s: String): String = "\"" + s + "\""
 
-  property("unicode is ok") {
-    isValidSyntax(qs("ö")) shouldBe true
-    isValidSyntax(qs("ö\\\\")) shouldBe true
-    isValidSyntax(qs("\\\\ö")) shouldBe true
+  property("unicode is ok") = {
+    isValidSyntax(qs("ö")) 
+    isValidSyntax(qs("ö\\\\")) 
+    isValidSyntax(qs("\\\\ö")) 
   }
 
-  property("invalid unicode is invalid") {
-    isValidSyntax("\"\\uqqqq\"") shouldBe false
+  property("invalid unicode is invalid") = {
+    isValidSyntax("\"\\uqqqq\"") != true
   }
 
-  property("empty is invalid") { isValidSyntax("") shouldBe false }
-  property("} is invalid") { isValidSyntax("}") shouldBe false }
+  property("empty is invalid") = { isValidSyntax("") != true }
+  property("} is invalid") = { isValidSyntax("}") != true }
 
-  property("literal TAB is invalid") { isValidSyntax(qs("\t")) shouldBe false }
-  property("literal NL is invalid") { isValidSyntax(qs("\n")) shouldBe false }
-  property("literal CR is invalid") { isValidSyntax(qs("\r")) shouldBe false }
-  property("literal NUL is invalid") { isValidSyntax(qs("\u0000")) shouldBe false }
-  property("literal BS TAB is invalid") { isValidSyntax(qs("\\\t")) shouldBe false }
-  property("literal BS NL is invalid") { isValidSyntax(qs("\\\n")) shouldBe false }
-  property("literal BS CR is invalid") { isValidSyntax(qs("\\\r")) shouldBe false }
-  property("literal BS NUL is invalid") { isValidSyntax(qs("\\\u0000")) shouldBe false }
-  property("literal BS ZERO is invalid") { isValidSyntax(qs("\\0")) shouldBe false }
-  property("literal BS X is invalid") { isValidSyntax(qs("\\x")) shouldBe false }
+  property("literal TAB is invalid") = { isValidSyntax(qs("\t")) != true }
+  property("literal NL is invalid") = { isValidSyntax(qs("\n")) != true }
+  property("literal CR is invalid") = { isValidSyntax(qs("\r")) != true }
+  property("literal NUL is invalid") = { isValidSyntax(qs("\u0000")) != true }
+  property("literal BS TAB is invalid") = { isValidSyntax(qs("\\\t")) != true }
+  property("literal BS NL is invalid") = { isValidSyntax(qs("\\\n")) != true }
+  property("literal BS CR is invalid") = { isValidSyntax(qs("\\\r")) != true }
+  property("literal BS NUL is invalid") = { isValidSyntax(qs("\\\u0000")) != true }
+  property("literal BS ZERO is invalid") = { isValidSyntax(qs("\\0")) != true }
+  property("literal BS X is invalid") = { isValidSyntax(qs("\\x")) != true }
 
-  property("0 is ok") { isValidSyntax("0") shouldBe true }
-  property("0e is invalid") { isValidSyntax("0e") shouldBe false }
-  property("123e is invalid") { isValidSyntax("123e") shouldBe false }
-  property(".999 is invalid") { isValidSyntax(".999") shouldBe false }
-  property("0.999 is ok") { isValidSyntax("0.999") shouldBe true }
-  property("-.999 is invalid") { isValidSyntax("-.999") shouldBe false }
-  property("-0.999 is ok") { isValidSyntax("-0.999") shouldBe true }
-  property("+0.999 is invalid") { isValidSyntax("+0.999") shouldBe false }
-  property("--0.999 is invalid") { isValidSyntax("--0.999") shouldBe false }
-  property("01 is invalid") { isValidSyntax("01") shouldBe false }
-  property("1e is invalid") { isValidSyntax("1e") shouldBe false }
-  property("1e- is invalid") { isValidSyntax("1e+") shouldBe false }
-  property("1e+ is invalid") { isValidSyntax("1e-") shouldBe false }
-  property("1. is invalid") { isValidSyntax("1.") shouldBe false }
-  property("1.e is invalid") { isValidSyntax("1.e") shouldBe false }
-  property("1.e9 is invalid") { isValidSyntax("1.e9") shouldBe false }
-  property("1.e- is invalid") { isValidSyntax("1.e+") shouldBe false }
-  property("1.e+ is invalid") { isValidSyntax("1.e-") shouldBe false }
-  property("1.1e is invalid") { isValidSyntax("1.1e") shouldBe false }
-  property("1.1e- is invalid") { isValidSyntax("1.1e-") shouldBe false }
-  property("1.1e+ is invalid") { isValidSyntax("1.1e+") shouldBe false }
-  property("1.1e1 is ok") { isValidSyntax("1.1e1") shouldBe true }
-  property("1.1e-1 is ok") { isValidSyntax("1.1e-1") shouldBe true }
-  property("1.1e+1 is ok") { isValidSyntax("1.1e+1") shouldBe true }
-  property("1+ is invalid") { isValidSyntax("1+") shouldBe false }
-  property("1- is invalid") { isValidSyntax("1-") shouldBe false }
+  property("0 is ok") = { isValidSyntax("0")  }
+  property("0e is invalid") = { isValidSyntax("0e") != true }
+  property("123e is invalid") = { isValidSyntax("123e") != true }
+  property(".999 is invalid") = { isValidSyntax(".999") != true }
+  property("0.999 is ok") = { isValidSyntax("0.999")  }
+  property("-.999 is invalid") = { isValidSyntax("-.999") != true }
+  property("-0.999 is ok") = { isValidSyntax("-0.999")  }
+  property("+0.999 is invalid") = { isValidSyntax("+0.999") != true }
+  property("--0.999 is invalid") = { isValidSyntax("--0.999") != true }
+  property("01 is invalid") = { isValidSyntax("01") != true }
+  property("1e is invalid") = { isValidSyntax("1e") != true }
+  property("1e- is invalid") = { isValidSyntax("1e+") != true }
+  property("1e+ is invalid") = { isValidSyntax("1e-") != true }
+  property("1. is invalid") = { isValidSyntax("1.") != true }
+  property("1.e is invalid") = { isValidSyntax("1.e") != true }
+  property("1.e9 is invalid") = { isValidSyntax("1.e9") != true }
+  property("1.e- is invalid") = { isValidSyntax("1.e+") != true }
+  property("1.e+ is invalid") = { isValidSyntax("1.e-") != true }
+  property("1.1e is invalid") = { isValidSyntax("1.1e") != true }
+  property("1.1e- is invalid") = { isValidSyntax("1.1e-") != true }
+  property("1.1e+ is invalid") = { isValidSyntax("1.1e+") != true }
+  property("1.1e1 is ok") = { isValidSyntax("1.1e1")  }
+  property("1.1e-1 is ok") = { isValidSyntax("1.1e-1")  }
+  property("1.1e+1 is ok") = { isValidSyntax("1.1e+1")  }
+  property("1+ is invalid") = { isValidSyntax("1+") != true }
+  property("1- is invalid") = { isValidSyntax("1-") != true }
 
   def isStackSafe(s: String): Try[Boolean] =
     try {
@@ -150,42 +146,41 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
 
   val S = "     " * 2000
 
-  property("stack-safety 1") {
-    isStackSafe(s"${S}[${S}null${S}]${S}") shouldBe Success(true)
+  property("stack-safety 1") = {
+    Claim(isStackSafe(s"${S}[${S}null${S}]${S}") == Success(true))
   }
 
-  property("stack-safety 2") {
-    isStackSafe(s"${S}[${S}nul${S}]${S}") shouldBe Success(false)
+  property("stack-safety 2") = {
+    Claim(isStackSafe(s"${S}[${S}nul${S}]${S}") == Success(false))
   }
 
-  property("stack-safety 3") {
-    isStackSafe(S) shouldBe Success(false)
+  property("stack-safety 3") = {
+    Claim(isStackSafe(S) == Success(false))
   }
 
-  property("stack-safety 4") {
-    isStackSafe(s"${S}false${S}") shouldBe Success(true)
+  property("stack-safety 4") = {
+    Claim(isStackSafe(s"${S}false${S}") == Success(true))
   }
 
-  property("stack-safety 5") {
-    isStackSafe(s"${S}fals\\u0065${S}") shouldBe Success(false)
+  property("stack-safety 5") = {
+    Claim(isStackSafe(s"${S}fals\\u0065${S}") == Success(false))
   }
 
-  property("stack-safety 6") {
-    isStackSafe(s"${S}fals${S}") shouldBe Success(false)
+  property("stack-safety 6") = {
+    Claim(isStackSafe(s"${S}fals${S}") == Success(false))
   }
 
-  property("stack-safety 7") {
-    isStackSafe(s"false${S}false") shouldBe Success(false)
+  property("stack-safety 7") = {
+    Claim(isStackSafe(s"false${S}false") == Success(false))
   }
 
-  property("stack-safety 8") {
-    isStackSafe(s"false${S},${S}false") shouldBe Success(false)
+  property("stack-safety 8") = {
+    Claim(isStackSafe(s"false${S},${S}false") == Success(false))
   }
 
-  def testErrorLoc(json: String, line: Int, col: Int): Unit = {
+  def testErrorLoc(json: String, line: Int, col: Int): Prop = {
     import java.io.ByteArrayInputStream
     import java.nio.channels.{Channels, ReadableByteChannel}
-    isValidSyntax(json) shouldBe false
 
     def ch(s: String): ReadableByteChannel =
       Channels.newChannel(new ByteArrayInputStream(s.getBytes("UTF-8")))
@@ -193,50 +188,52 @@ class SyntaxCheck extends PropSpec with Matchers with PropertyChecks {
     def bb(s: String): ByteBuffer =
       ByteBuffer.wrap(s.getBytes("UTF-8"))
 
-    def assertLoc(p: ParseException): Unit = {
-      p.line shouldBe line
-      p.col shouldBe col
-    }
+    def assertLoc(p: ParseException): Prop =
+      Claim(p.line == line && p.col == col)
 
-    def extract1(t: Try[Unit]): Unit =
+    def fail(msg: String): Prop =
+      Prop.falsified :| msg
+
+    def extract1(t: Try[Unit]): Prop =
       t match {
         case Failure(p @ ParseException(_, _, _, _)) => assertLoc(p)
         case otherwise => fail(s"expected Failure(ParseException), got $otherwise")
       }
 
-    def extract2(e: Either[ParseException, collection.Seq[Unit]]): Unit =
+    def extract2(e: Either[ParseException, collection.Seq[Unit]]): Prop =
       e match {
         case Left(p) => assertLoc(p)
         case right => fail(s"expected Left(ParseException), got $right")
       }
 
-    extract1(Parser.parseFromString(json)(NullFacade))
-    extract1(Parser.parseFromCharSequence(json)(NullFacade))
-    extract1(Parser.parseFromChannel(ch(json))(NullFacade))
-    extract1(Parser.parseFromByteBuffer(bb(json))(NullFacade))
-    extract2(Parser.async(AsyncParser.UnwrapArray)(NullFacade).finalAbsorb(json)(NullFacade))
+    Claim(isValidSyntax(json) != true) &&
+      extract1(Parser.parseFromString(json)(NullFacade)) &&
+      extract1(Parser.parseFromCharSequence(json)(NullFacade)) &&
+      extract1(Parser.parseFromChannel(ch(json))(NullFacade)) &&
+      extract1(Parser.parseFromByteBuffer(bb(json))(NullFacade)) &&
+      extract2(Parser.async(AsyncParser.UnwrapArray)(NullFacade).finalAbsorb(json)(NullFacade))
   }
 
-  property("error location 1") { testErrorLoc("[1, 2,\nx3]", 2, 1) }
-  property("error location 2") { testErrorLoc("[1, 2,    \n   x3]", 2, 4) }
-  property("error location 3") { testErrorLoc("[1, 2,\n\n\n\n\nx3]", 6, 1) }
-  property("error location 4") { testErrorLoc("[1, 2,\n\n3,\n4,\n\n x3]", 6, 2) }
+  property("error location 1") = { testErrorLoc("[1, 2,\nx3]", 2, 1) }
+  property("error location 2") = { testErrorLoc("[1, 2,    \n   x3]", 2, 4) }
+  property("error location 3") = { testErrorLoc("[1, 2,\n\n\n\n\nx3]", 6, 1) }
+  property("error location 4") = { testErrorLoc("[1, 2,\n\n3,\n4,\n\n x3]", 6, 2) }
 
-  property("no extra \" in error message") {
+  property("no extra \" in error message") = {
     val result = Parser.parseFromString("\"\u0000\"")(NullFacade)
     val expected = "control char (0) in string got '\u0000...' (line 1, column 2)"
-    result.failed.get.getMessage shouldBe expected
+    Claim(result.failed.get.getMessage == expected)
   }
 
-  property("absorb should fail fast on bad inputs") {
+  property("absorb should fail fast on bad inputs") = {
+
     def absorbFails(in: String): Boolean = {
       val async = AsyncParser[Unit](AsyncParser.UnwrapArray)
       async.absorb("}")(NullFacade).isLeft
     }
 
     val badInputs = Seq("}", "fälse", "n0ll", "try", "0x", "0.x", "0ex", "[1; 2]", "{\"a\"; 1}", "{1: 2}")
-    badInputs.foreach { input =>
-      absorbFails(input) shouldBe true
-    }
+
+    Claim(badInputs.forall(absorbFails))
   }
 }

--- a/parser/src/test/scala/jawn/TestUtil.scala
+++ b/parser/src/test/scala/jawn/TestUtil.scala
@@ -1,7 +1,7 @@
 package org.typelevel.jawn
 package parser
 
-import java.io._
+import java.io.{File, PrintWriter}
 
 object TestUtil {
   def withTemp[A](s: String)(f: File => A): A = {

--- a/support/argonaut/src/test/scala/ParserSpec.scala
+++ b/support/argonaut/src/test/scala/ParserSpec.scala
@@ -1,13 +1,14 @@
 package org.typelevel.jawn
 package support.argonaut
 
-import argonaut._
-import Argonaut._
-import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary.arbitrary
-import org.scalatest.prop.Checkers
-import org.scalatest.{Matchers, FlatSpec}
+import argonaut.{Argonaut, CodecJson, Json}
+import claimant.Claim
+import org.scalacheck.{Arbitrary, Prop, Properties}
 import scala.util.Try
+
+import Arbitrary.arbitrary
+import Argonaut._
+import Prop.forAll
 
 object ParserSpec {
   case class Example(a: Int, b: Long, c: Double)
@@ -15,27 +16,23 @@ object ParserSpec {
   val exampleCodecJson: CodecJson[Example] =
     casecodec3(Example.apply, Example.unapply)("a", "b", "c")
 
-  implicit val exampleCaseClassArbitrary: Arbitrary[Example] = Arbitrary(
-    for {
+  implicit val exampleCaseClassArbitrary: Arbitrary[Example] =
+    Arbitrary(for {
       a <- arbitrary[Int]
       b <- arbitrary[Long]
       c <- arbitrary[Double]
-    } yield Example(a, b, c)
-  )
+    } yield Example(a, b, c))
 }
 
-class ParserSpec extends FlatSpec with Matchers with Checkers {
+class ParserSpec extends Properties("ParserSpec") {
+
   import ParserSpec._
   import org.typelevel.jawn.support.argonaut.Parser.facade
 
-  "The Argonaut support Parser" should "correctly marshal case classes with Long values" in {
-    check { (e: Example) =>
+  property("argonaut support correctly marshals case class with Long values") =
+    forAll { (e: Example) =>
       val jsonString: String = exampleCodecJson.encode(e).nospaces
       val json: Try[Json] = org.typelevel.jawn.Parser.parseFromString(jsonString)
-      exampleCodecJson.decodeJson(json.get).toOption match {
-        case None => fail()
-        case Some(example) => example == e
-      }
+      Claim(exampleCodecJson.decodeJson(json.get).toOption == Some(e))
     }
-  }
 }

--- a/util/src/test/scala/jawn/util/ParseLongCheck.scala
+++ b/util/src/test/scala/jawn/util/ParseLongCheck.scala
@@ -1,13 +1,14 @@
 package org.typelevel.jawn
 package util
 
-import org.scalatest._
-import prop._
-import org.scalacheck._
+import claimant.Claim
+import org.scalacheck.{Arbitrary, Gen, Prop, Properties, Test}
+import scala.util.{Failure, Success, Try}
 
-import scala.util._
+import Arbitrary.arbitrary
+import Prop.forAll
 
-class ParseLongCheck extends PropSpec with Matchers with PropertyChecks {
+class ParseLongCheck extends Properties("ParseLongCheck") {
 
   case class UniformLong(value: Long)
 
@@ -16,54 +17,61 @@ class ParseLongCheck extends PropSpec with Matchers with PropertyChecks {
       Arbitrary(Gen.choose(Long.MinValue, Long.MaxValue).map(UniformLong(_)))
   }
 
-  property("both parsers accept on valid input") {
+  property("both parsers accept on valid input") =
     forAll { (n0: UniformLong, prefix: String, suffix: String) =>
+      // new Exception("ok").printStackTrace()
+      // sys.error("!")
       val n = n0.value
       val payload = n.toString
       val s = prefix + payload + suffix
       val i = prefix.length
       val cs = s.subSequence(i, payload.length + i)
-      cs.toString shouldBe payload
-      parseLong(cs) shouldBe n
-      parseLongUnsafe(cs) shouldBe n
+      Claim(
+        cs.toString == payload &&
+        parseLong(cs) == n &&
+        parseLongUnsafe(cs) == n)
     }
 
+  property("parsers agree on random input") =
     forAll { (s: String) =>
       Try(parseLong(s)) match {
-        case Success(n) => parseLongUnsafe(s) shouldBe n
-        case Failure(_) => succeed
-      }
-    }
-  }
-
-  property("safe parser fails on invalid input") {
-    forAll { (n: Long, m: Long, suffix: String) =>
-      val s1 = n.toString + suffix
-      Try(parseLong(s1)) match {
-        case Success(n) => n shouldBe s1.toLong
-        case Failure(_) => Try(s1.toLong).isFailure
-      }
-
-      val s2 = n.toString + (m & 0x7fffffffffffffffL).toString
-      Try(parseLong(s2)) match {
-        case Success(n) => n shouldBe s2.toLong
-        case Failure(_) => Try(s2.toLong).isFailure
+        case Success(n) => Claim(parseLongUnsafe(s) == n)
+        case Failure(_) => Claim(true)
       }
     }
 
-    Try(parseLong("9223372036854775807")) shouldBe Try(Long.MaxValue)
-    Try(parseLong("-9223372036854775808")) shouldBe Try(Long.MinValue)
-    Try(parseLong("-0")) shouldBe Try(0L)
+  property("safe parser fails on invalid input") =
+    forAll { (n1: Long, m: Long, suffix: String) =>
+      val s1 = n1.toString + suffix
+      val p1 = Try(parseLong(s1)) match {
+        case Success(x) => Claim(x == s1.toLong)
+        case Failure(_) => Claim(Try(s1.toLong).isFailure)
+      }
 
-    assert(Try(parseLong("")).isFailure)
-    assert(Try(parseLong("+0")).isFailure)
-    assert(Try(parseLong("00")).isFailure)
-    assert(Try(parseLong("01")).isFailure)
-    assert(Try(parseLong("+1")).isFailure)
-    assert(Try(parseLong("-")).isFailure)
-    assert(Try(parseLong("--1")).isFailure)
-    assert(Try(parseLong("9223372036854775808")).isFailure)
-    assert(Try(parseLong("-9223372036854775809")).isFailure)
+      // avoid leading zeros, which .toLong is lax about
+      val n2 = if (n1 == 0L) 1L else n1
+      val s2 = n2.toString + (m & 0x7fffffffffffffffL).toString
+      val p2 = Try(parseLong(s2)) match {
+        case Success(x) => Claim(x == s2.toLong)
+        case Failure(_) => Claim(Try(s2.toLong).isFailure)
+      }
+
+      p1 && p2
+    }
+
+  property("safe parser fails on test cases") = {
+    Claim(parseLong("9223372036854775807") == Long.MaxValue) &&
+      Claim(parseLong("-9223372036854775808") == Long.MinValue) &&
+      Claim(parseLong("-0") == 0L) &&
+      Claim(Try(parseLong("")).isFailure) &&
+      Claim(Try(parseLong("+0")).isFailure) &&
+      Claim(Try(parseLong("00")).isFailure) &&
+      Claim(Try(parseLong("01")).isFailure) &&
+      Claim(Try(parseLong("+1")).isFailure) &&
+      Claim(Try(parseLong("-")).isFailure) &&
+      Claim(Try(parseLong("--1")).isFailure) &&
+      Claim(Try(parseLong("9223372036854775808")).isFailure) &&
+      Claim(Try(parseLong("-9223372036854775809")).isFailure)
   }
 
   // NOTE: parseLongUnsafe is not guaranteed to crash, or do anything


### PR DESCRIPTION
This commit takes care of a lot of deferred maintenance that this project has
been waiting on. Specifically, it:

 1. Removes support for Scala 2.10
 2. Removes 2.10-specific build stuff
 3. Removes ScalaTest in favor of pure ScalaCheck + Claimant
 4. Cleans up the test code (especially imports)

Scala 2.11 has been out for almost 5 years, and libraries are increasingly
dropping 2.10 support. I think it's time for Jawn to do so as well, especially
since we haven't been releasing frequently. This allows us to clean up the
build a bit, and gives us a bit more flexibility around which scalac flags we
use, what library versions we depend on, etc.

Relatedly, I've decided to remove ScalaTest. Increasingly, I prefer a simpler
testing regime, and find that pure ScalaCheck serves my purposes fine now that
Claimant exists. The immediate impetus for this change are the deprecations
introduced by ScalaTest 3.0.7, but I think I would prefer this approach even if
that wasn't happening.

It also seems like some of the parameters ScalaTest uses to invoke ScalaCheck
trade coverage for speed (e.g. using smaller sizes). Moving back to pure
ScalaCheck I found a bug (in a test) which apparently we'd never hit before.

As long as I needed to revisit our test code I also took the opportunity to
clean up the test code a bit, primarily by removing wildcard imports in favor
of more tightly-scoped, explicit imports.