### PR TITLE
fix scalacOptions. -Xfuture is deprecated since Scala 2.13.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,8 +53,16 @@ lazy val jawnSettings = Seq(
     "-feature" ::
     "-unchecked" ::
     "-Xfatal-warnings" ::
-    "-Xfuture" ::
     Nil,
+
+  scalacOptions ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, v)) if v <= 12 =>
+        Seq("-Xfuture")
+      case _ =>
+        Nil
+    }
+  },
 
   scalacOptions += {
     CrossVersion.partialVersion(scalaVersion.value) match {


### PR DESCRIPTION
https://github.com/scala/scala/commit/67195a5cffadac9340b3228ee804e01a0fc02e25