### PR TITLE
2.13.0-RC1

### DIFF
--- a/ast/src/test/scala/jawn/AstTest.scala
+++ b/ast/src/test/scala/jawn/AstTest.scala
@@ -1,8 +1,8 @@
 package org.typelevel.jawn
 package ast
 
-import claimant.Claim
 import org.scalacheck.{Prop, Properties}
+import org.typelevel.claimant.Claim
 import scala.collection.mutable
 import scala.util.{Try, Success}
 

--- a/ast/src/test/scala/jawn/ParseCheck.scala
+++ b/ast/src/test/scala/jawn/ParseCheck.scala
@@ -1,8 +1,8 @@
 package org.typelevel.jawn
 package ast
 
-import claimant.Claim
 import org.scalacheck.{Arbitrary, Gen, Prop, Properties}
+import org.typelevel.claimant.Claim
 import org.typelevel.jawn.parser.TestUtil
 import scala.collection.mutable
 import scala.util.{Try, Success}

--- a/build.sbt
+++ b/build.sbt
@@ -142,7 +142,7 @@ lazy val supportJson4s = support("json4s")
 
 lazy val supportPlay = support("play")
   .settings(crossScalaVersions := allCrossVersions)
-  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.7.2")
+  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.7.3")
 
 lazy val supportRojoma = support("rojoma")
   .settings(crossScalaVersions := stableCrossVersions)

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val previousJawnVersion = "0.14.0"
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.8"
-lazy val scala213 = "2.13.0-M5"
+lazy val scala213 = "2.13.0-RC1"
 ThisBuild / scalaVersion := scala212
 ThisBuild / organization := "org.typelevel"
 ThisBuild / licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
@@ -25,7 +25,6 @@ ThisBuild / developers += Developer(
 lazy val stableCrossVersions =
   Seq(scala211, scala212)
 
-// we'll support 2.13.0-M5 soon but not yet
 lazy val allCrossVersions =
   stableCrossVersions :+ scala213
 
@@ -33,8 +32,7 @@ lazy val benchmarkVersion =
   scala212
 
 lazy val jawnSettings = Seq(
-  //crossScalaVersions := allCrossVersions,
-  crossScalaVersions := stableCrossVersions,
+  crossScalaVersions := allCrossVersions,
 
   mimaPreviousArtifacts := Set(organization.value %% moduleName.value % previousJawnVersion),
 
@@ -44,7 +42,7 @@ lazy val jawnSettings = Seq(
 
   libraryDependencies ++=
     "org.scalacheck" %% "scalacheck" % "1.14.0" % Test ::
-    "org.spire-math" %% "claimant" % "0.0.4" % Test ::
+    "org.typelevel" %% "claimant" % "0.0.5-SNAPSHOT" % Test ::
     Nil,
 
   scalacOptions ++=
@@ -52,7 +50,7 @@ lazy val jawnSettings = Seq(
     "-encoding" :: "utf-8" ::
     "-feature" ::
     "-unchecked" ::
-    "-Xfatal-warnings" ::
+    //"-Xfatal-warnings" ::
     "-Xfuture" ::
     Nil,
 
@@ -102,15 +100,14 @@ lazy val root = project.in(file("."))
   .aggregate(all.map(Project.projectToRef): _*)
   .disablePlugins(JmhPlugin)
   .settings(name := "jawn")
-  .settings(crossScalaVersions := List())
   .settings(jawnSettings: _*)
+  .settings(crossScalaVersions := List())
   .settings(noPublish: _*)
 
 lazy val parser = project.in(file("parser"))
   .settings(name := "parser")
   .settings(moduleName := "jawn-parser")
   .settings(jawnSettings: _*)
-  .settings(crossScalaVersions := allCrossVersions)
   .disablePlugins(JmhPlugin)
 
 lazy val util = project.in(file("util"))
@@ -118,7 +115,6 @@ lazy val util = project.in(file("util"))
   .settings(name := "util")
   .settings(moduleName := "jawn-util")
   .settings(jawnSettings: _*)
-  .settings(crossScalaVersions := allCrossVersions)
   .disablePlugins(JmhPlugin)
 
 lazy val ast = project.in(file("ast"))
@@ -127,7 +123,6 @@ lazy val ast = project.in(file("ast"))
   .settings(name := "ast")
   .settings(moduleName := "jawn-ast")
   .settings(jawnSettings: _*)
-  .settings(crossScalaVersions := allCrossVersions)
   .disablePlugins(JmhPlugin)
 
 def support(s: String) =
@@ -139,12 +134,10 @@ def support(s: String) =
     .disablePlugins(JmhPlugin)
 
 lazy val supportArgonaut = support("argonaut")
-  .settings(crossScalaVersions := stableCrossVersions)
   .settings(libraryDependencies += "io.argonaut" %% "argonaut" % "6.2.3")
 
 lazy val supportJson4s = support("json4s")
   .dependsOn(util)
-  .settings(crossScalaVersions := allCrossVersions)
   .settings(libraryDependencies += "org.json4s" %% "json4s-ast" % "3.6.5")
 
 lazy val supportPlay = support("play")
@@ -160,7 +153,6 @@ lazy val supportRojomaV3 = support("rojoma-v3")
   .settings(libraryDependencies += "com.rojoma" %% "rojoma-json-v3" % "3.9.1")
 
 lazy val supportSpray = support("spray")
-  .settings(crossScalaVersions := allCrossVersions)
   .settings(libraryDependencies += "io.spray" %% "spray-json" % "1.3.5")
 
 lazy val benchmark = project.in(file("benchmark"))
@@ -173,4 +165,4 @@ lazy val benchmark = project.in(file("benchmark"))
   .enablePlugins(JmhPlugin)
 
 lazy val all =
-  Seq(parser, util, ast, supportArgonaut, supportJson4s, supportPlay, supportRojoma, supportRojomaV3, supportSpray)
+  Seq(parser, util, ast, supportArgonaut, supportJson4s, supportPlay, supportSpray)

--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ lazy val jawnSettings = Seq(
 
   libraryDependencies ++=
     "org.scalacheck" %% "scalacheck" % "1.14.0" % Test ::
-    "org.typelevel" %% "claimant" % "0.0.5-SNAPSHOT" % Test ::
+    "org.typelevel" %% "claimant" % "0.1.0" % Test ::
     Nil,
 
   scalacOptions ++=

--- a/parser/src/test/scala/jawn/ChannelSpec.scala
+++ b/parser/src/test/scala/jawn/ChannelSpec.scala
@@ -1,9 +1,9 @@
 package org.typelevel.jawn
 package parser
 
-import claimant.Claim
 import java.nio.channels.ByteChannel
 import org.scalacheck.Properties
+import org.typelevel.claimant.Claim
 import scala.util.Success
 
 class ChannelSpec extends Properties("ChannelSpec") {

--- a/parser/src/test/scala/jawn/CharBuilderSpec.scala
+++ b/parser/src/test/scala/jawn/CharBuilderSpec.scala
@@ -1,8 +1,8 @@
 package org.typelevel.jawn
 
-import claimant.Claim
 import org.scalacheck.Properties
 import org.scalacheck.Prop.forAll
+import org.typelevel.claimant.Claim
 
 class CharBuilderSpec extends Properties("CharBuilderSpec") {
 

--- a/parser/src/test/scala/jawn/JNumIndexCheck.scala
+++ b/parser/src/test/scala/jawn/JNumIndexCheck.scala
@@ -1,10 +1,10 @@
 package org.typelevel.jawn
 package parser
 
-import claimant.Claim
 import java.nio.ByteBuffer
 import org.scalacheck.Properties
 import org.scalacheck.Prop.forAll
+import org.typelevel.claimant.Claim
 import scala.util.Success
 
 class JNumIndexCheck extends Properties("JNumIndexCheck") {

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -1,9 +1,9 @@
 package org.typelevel.jawn
 package parser
 
-import claimant.Claim
 import java.nio.ByteBuffer
 import org.scalacheck.{Arbitrary, Gen, Prop, Properties}
+import org.typelevel.claimant.Claim
 import scala.util.{Try, Success, Failure}
 
 import Arbitrary.arbitrary

--- a/support/argonaut/src/test/scala/ParserSpec.scala
+++ b/support/argonaut/src/test/scala/ParserSpec.scala
@@ -2,8 +2,8 @@ package org.typelevel.jawn
 package support.argonaut
 
 import argonaut.{Argonaut, CodecJson, Json}
-import claimant.Claim
 import org.scalacheck.{Arbitrary, Prop, Properties}
+import org.typelevel.claimant.Claim
 import scala.util.Try
 
 import Arbitrary.arbitrary

--- a/util/src/test/scala/jawn/util/ParseLongCheck.scala
+++ b/util/src/test/scala/jawn/util/ParseLongCheck.scala
@@ -1,8 +1,8 @@
 package org.typelevel.jawn
 package util
 
-import claimant.Claim
 import org.scalacheck.{Arbitrary, Gen, Prop, Properties, Test}
+import org.typelevel.claimant.Claim
 import scala.util.{Failure, Success, Try}
 
 import Arbitrary.arbitrary

--- a/util/src/test/scala/jawn/util/SliceCheck.scala
+++ b/util/src/test/scala/jawn/util/SliceCheck.scala
@@ -1,8 +1,8 @@
 package org.typelevel.jawn
 package util
 
-import claimant.Claim
 import org.scalacheck.{Arbitrary, Gen, Prop, Properties}
+import org.typelevel.claimant.Claim
 import scala.util.{Failure, Success, Try}
 
 import Arbitrary.arbitrary


### PR DESCRIPTION
This will need updating when Claimant is released, but I confirmed that it works locally with `sbt +test` and `sbt +publishLocal`. I've removed the Rojoma support modules from aggregation (they're the only ones with no 2.13 support), so they'll need to be published manually, which is annoying but seems better than publishing the 2.13.0-RC1 artifacts manually.