### PR TITLE
2.13.0-RC2 support with cross-versioned play

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ arbitrary data type (provided you also have an implicit `Facade[J]`).
 
 Jawn currently integrates three external ASTs directly:
 
-| AST       | Version |
-|-----------|---------|
-| Json4s    | 3.6.5   |
-| Play-json | 2.7.3   |
-| Spray     | 1.3.5   |
+| AST       | Scala 2.11 | Scala 2.12 | Scala 2.13 |
+|-----------|------------|------------|------------|
+| Json4s    | 3.6.6      | 3.6.6      | 3.6.6      |
+| Play-json | 2.7.3      | 2.8.0-M1   | 2.8.0-M1   |
+| Spray     | 1.3.5      | 1.3.5      | 1.3.5      |
 
 Integrations for [circe] and [argonaut] are maintained by those
 projects.

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val previousJawnVersion = "0.14.0"
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.8"
-lazy val scala213 = "2.13.0-RC1"
+lazy val scala213 = "2.13.0-RC2"
 ThisBuild / scalaVersion := scala212
 ThisBuild / organization := "org.typelevel"
 ThisBuild / licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
@@ -22,17 +22,11 @@ ThisBuild / developers += Developer(
   url = url("http://github.com/non/")
 )
 
-lazy val stableCrossVersions =
-  Seq(scala211, scala212)
-
-lazy val allCrossVersions =
-  stableCrossVersions :+ scala213
-
 lazy val benchmarkVersion =
   scala212
 
 lazy val jawnSettings = Seq(
-  crossScalaVersions := allCrossVersions,
+  crossScalaVersions := Seq(scala211, scala212, scala213),
 
   mimaPreviousArtifacts := Set(organization.value %% moduleName.value % previousJawnVersion),
 
@@ -43,7 +37,7 @@ lazy val jawnSettings = Seq(
 
   libraryDependencies ++=
     "org.scalacheck" %% "scalacheck" % "1.14.0" % Test ::
-    "org.typelevel" %% "claimant" % "0.1.0" % Test ::
+    "org.typelevel" %% "claimant" % "0.1.1" % Test ::
     Nil,
 
   scalacOptions ++=
@@ -146,8 +140,8 @@ lazy val supportJson4s = support("json4s")
   .settings(libraryDependencies += "org.json4s" %% "json4s-ast" % "3.6.6")
 
 lazy val supportPlay = support("play")
-  .settings(crossScalaVersions := allCrossVersions)
-  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.7.3")
+  .settings(crossScalaVersions := Seq(scala212, scala213))
+  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.8.0-M1")
 
 lazy val supportSpray = support("spray")
   .settings(libraryDependencies += "io.spray" %% "spray-json" % "1.3.5")

--- a/build.sbt
+++ b/build.sbt
@@ -140,8 +140,13 @@ lazy val supportJson4s = support("json4s")
   .settings(libraryDependencies += "org.json4s" %% "json4s-ast" % "3.6.6")
 
 lazy val supportPlay = support("play")
-  .settings(crossScalaVersions := Seq(scala212, scala213))
-  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.8.0-M1")
+  .settings(libraryDependencies += {
+    val playVersion = CrossVersion.binaryScalaVersion(scalaVersion.value) match {
+      case "2.11" => "2.7.3"
+      case _      => "2.8.0-M1"
+    }
+    "com.typesafe.play" %% "play-json" % playVersion
+  })
 
 lazy val supportSpray = support("spray")
   .settings(libraryDependencies += "io.spray" %% "spray-json" % "1.3.5")


### PR DESCRIPTION
Extension of #169, but keeps Play support for 2.11.

Argument in favor of this: projects downstream (e.g., http4s) won't need to choose between cross-versioning jawn and partially dropping modules.  This cross-versioning will be viral.

Argument against this: if Play has dropped 2.11 support, there's no reason for anything downstream (jawn, jawn-fs2, http4s) to keep it alive.  Giving jawn separate dependencies downstream might be a nuisance to some downstream projects anyway.

