### PR TITLE
Update to 2.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val previousJawnVersion = "0.14.0"
 
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.8"
-lazy val scala213 = "2.13.0-RC3"
+lazy val scala213 = "2.13.0"
 ThisBuild / scalaVersion := scala212
 ThisBuild / organization := "org.typelevel"
 ThisBuild / licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
@@ -144,6 +144,7 @@ lazy val supportPlay = support("play")
   .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.7.3")
 
 lazy val supportSpray = support("spray")
+  .settings(crossScalaVersions := Seq(scala211, scala212))
   .settings(libraryDependencies += "io.spray" %% "spray-json" % "1.3.5")
 
 lazy val benchmark = project.in(file("benchmark"))

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -46,10 +46,10 @@ class SyntaxCheck extends Properties("SyntaxCheck") {
 
   def jvalue(lvl: Int): Gen[J] =
     if (lvl < 3) {
-      Gen.frequency((16, 'ato), (1, 'arr), (2, 'obj)).flatMap {
-        case 'ato => jatom
-        case 'arr => jarray(lvl)
-        case 'obj => jobject(lvl)
+      Gen.frequency((16, Symbol("ato")), (1, Symbol("arr")), (2, Symbol("obj"))).flatMap {
+        case Symbol("ato") => jatom
+        case Symbol("arr") => jarray(lvl)
+        case Symbol("obj") => jobject(lvl)
       }
     } else {
       jatom


### PR DESCRIPTION
Temporarily disables the 2.13 build for the spray-json module. I'll go ahead and publish an 0.14.2 of the relevant modules for Scala 2.13.0 once this is merged.

r? @larsrh