### PR TITLE
Use non-empty representation of stack

### DIFF
--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -26,7 +26,7 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
 
   protected[this] final def close(): Unit = { src.position(src.limit) }
   protected[this] final def reset(i: Int): Int = i
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]): Unit = {}
+  protected[this] final def checkpoint(state: Int, i: Int, context: RawFContext[J], stack: List[RawFContext[J]]): Unit = {}
   protected[this] final def byte(i: Int): Byte = src.get(i + start)
   protected[this] final def at(i: Int): Char = src.get(i + start).toChar
 

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -113,7 +113,7 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
       i
     }
 
-  protected[this] final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]): Unit = ()
+  protected[this] final def checkpoint(state: Int, i: Int, context: RawFContext[J], stack: List[RawFContext[J]]): Unit = ()
 
   /**
    * This is a specialized accessor for the case where our underlying

--- a/parser/src/main/scala/jawn/CharSequenceParser.scala
+++ b/parser/src/main/scala/jawn/CharSequenceParser.scala
@@ -11,7 +11,7 @@ private[jawn] final class CharSequenceParser[J](cs: CharSequence) extends SyncPa
   final def column(i: Int) = i - offset
   final def newline(i: Int): Unit = { line += 1; offset = i + 1 }
   final def reset(i: Int): Int = i
-  final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]): Unit = ()
+  final def checkpoint(state: Int, i: Int, context: RawFContext[J], stack: List[RawFContext[J]]): Unit = ()
   final def at(i: Int): Char = cs.charAt(i)
   final def at(i: Int, j: Int): CharSequence = cs.subSequence(i, j)
   final def atEof(i: Int) = i == cs.length

--- a/parser/src/main/scala/jawn/StringParser.scala
+++ b/parser/src/main/scala/jawn/StringParser.scala
@@ -18,7 +18,7 @@ private[jawn] final class StringParser[J](s: String) extends SyncParser[J] with 
   final def column(i: Int) = i - offset
   final def newline(i: Int): Unit = { line += 1; offset = i + 1 }
   final def reset(i: Int): Int = i
-  final def checkpoint(state: Int, i: Int, stack: List[RawFContext[J]]): Unit = ()
+  final def checkpoint(state: Int, i: Int, context: RawFContext[J], stack: List[RawFContext[J]]): Unit = {}
   final def at(i: Int): Char = s.charAt(i)
   final def at(i: Int, j: Int): CharSequence = s.substring(i, j)
   final def atEof(i: Int) = i == s.length


### PR DESCRIPTION
Another ancient change I found that I never PR'd. It feels a little nicer to me in that you can't pass an invalid empty stack (and don't have to handle that case with an `error`), and it also avoids some cons-ing and uncons-ing.