### PR TITLE
Upcast ByteBuffer before calling position(I)

### DIFF
--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -1,7 +1,7 @@
 package org.typelevel.jawn
 
 import scala.annotation.{switch, tailrec}
-import java.nio.ByteBuffer
+import java.nio.{ByteBuffer, Buffer}
 
 /**
  * Basic ByteBuffer parser.
@@ -24,7 +24,7 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
   protected[this] final def newline(i: Int): Unit = { lineState += 1; offset = i + 1 }
   protected[this] final def column(i: Int) = i - offset
 
-  protected[this] final def close(): Unit = { src.position(src.limit) }
+  protected[this] final def close(): Unit = { (src: Buffer).position(src.limit) }
   protected[this] final def reset(i: Int): Int = i
   protected[this] final def checkpoint(state: Int, i: Int, context: RawFContext[J], stack: List[RawFContext[J]]): Unit = {}
   protected[this] final def byte(i: Int): Byte = src.get(i + start)
@@ -33,9 +33,9 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
   protected[this] final def at(i: Int, k: Int): CharSequence = {
     val len = k - i
     val arr = new Array[Byte](len)
-    src.position(i + start)
+    (src: Buffer).position(i + start)
     src.get(arr, 0, len)
-    src.position(start)
+    (src: Buffer).position(start)
     new String(arr, utf8)
   }
 


### PR DESCRIPTION
Addresses #200 (which is the same problem as e.g. [here](https://github.com/functional-streams-for-scala/fs2/issues/1357)). I think we should publish with JDK 8 to be safe, but this seems to resolve the issue even when compiling on 11.

@larsrh Do you mind taking a quick look so I can publish a 1.0.0-RC2?