### PR TITLE
Fix decoding hex values in unicode escapes

### DIFF
--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -551,7 +551,7 @@ object Parser {
     var i = 0
     while (i < 10) { arr(i + '0') = i; i += 1 }
     i = 0
-    while (i < 16) { arr(i + 'a') = 10 + i; arr(i + 'A') = 10 + i; i += 1 }
+    while (i < 6) { arr(i + 'a') = 10 + i; arr(i + 'A') = 10 + i; i += 1 }
     arr
   }
 

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -92,7 +92,15 @@ class SyntaxCheck extends Properties("SyntaxCheck") {
   }
 
   property("invalid unicode is invalid") = {
-    isValidSyntax("\"\\uqqqq\"") != true
+    isValidSyntax("\"\\uqqqq\"") != true &&
+    isValidSyntax("\"\\ughij\"") != true &&
+    isValidSyntax("\"\\uklmn\"") != true &&
+    isValidSyntax("\"\\uopqr\"") != true &&
+    isValidSyntax("\"\\ustuv\"") != true &&
+    isValidSyntax("\"\\uwxyz\"") != true &&
+    isValidSyntax("\"\\u1\"") != true &&
+    isValidSyntax("\"\\u12\"") != true &&
+    isValidSyntax("\"\\u123\"") != true
   }
 
   property("empty is invalid") = { isValidSyntax("") != true }

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -91,8 +91,16 @@ class SyntaxCheck extends Properties("SyntaxCheck") {
     isValidSyntax(qs("\\\\ö")) 
   }
 
+  property("valid unicode is ok") = {
+    isValidSyntax("\"\\u0000\"") &&
+    isValidSyntax("\"\\uffff\"") &&
+    isValidSyntax("\"\\uFFFF\"")
+  }
+
   property("invalid unicode is invalid") = {
     isValidSyntax("\"\\uqqqq\"") != true &&
+    isValidSyntax("\"\\ugggg\"") != true &&
+    isValidSyntax("\"\\uGGGG\"") != true &&
     isValidSyntax("\"\\ughij\"") != true &&
     isValidSyntax("\"\\uklmn\"") != true &&
     isValidSyntax("\"\\uopqr\"") != true &&


### PR DESCRIPTION
Avoids decoding invalid strings like `"\ughij"`