### PR TITLE
Some small changes for Dotty compatibility

### DIFF
--- a/ast/src/main/scala/jawn/ast/JParser.scala
+++ b/ast/src/main/scala/jawn/ast/JParser.scala
@@ -7,7 +7,7 @@ import java.nio.channels.ReadableByteChannel
 import scala.util.Try
 
 object JParser {
-  implicit val facade = JawnFacade
+  implicit val facade: Facade[JValue] = JawnFacade
 
   def parseUnsafe(s: String): JValue =
     new StringParser(s).parse()

--- a/ast/src/main/scala/jawn/ast/JParser.scala
+++ b/ast/src/main/scala/jawn/ast/JParser.scala
@@ -13,22 +13,22 @@ object JParser {
     new StringParser(s).parse()
 
   def parseFromString(s: String): Try[JValue] =
-    Try(new StringParser[JValue](s).parse)
+    Try(new StringParser[JValue](s).parse())
 
   def parseFromCharSequence(cs: CharSequence): Try[JValue] =
-    Try(new CharSequenceParser[JValue](cs).parse)
+    Try(new CharSequenceParser[JValue](cs).parse())
 
   def parseFromPath(path: String): Try[JValue] =
     parseFromFile(new File(path))
 
   def parseFromFile(file: File): Try[JValue] =
-    Try(ChannelParser.fromFile[JValue](file).parse)
+    Try(ChannelParser.fromFile[JValue](file).parse())
 
   def parseFromChannel(ch: ReadableByteChannel): Try[JValue] =
-    Try(ChannelParser.fromChannel(ch).parse)
+    Try(ChannelParser.fromChannel(ch).parse())
 
   def parseFromByteBuffer(buf: ByteBuffer): Try[JValue] =
-    Try(new ByteBufferParser[JValue](buf).parse)
+    Try(new ByteBufferParser[JValue](buf).parse())
 
   def async(mode: AsyncParser.Mode): AsyncParser[JValue] =
     AsyncParser(mode)

--- a/ast/src/main/scala/jawn/ast/JawnFacade.scala
+++ b/ast/src/main/scala/jawn/ast/JawnFacade.scala
@@ -24,7 +24,7 @@ object JawnFacade extends Facade[JValue] {
       var value: JValue = _
       def add(s: CharSequence): Unit = { value = JString(s.toString) }
       def add(v: JValue): Unit = { value = v }
-      def finish: JValue = value
+      def finish(): JValue = value
       def isObj: Boolean = false
     }
 
@@ -33,7 +33,7 @@ object JawnFacade extends Facade[JValue] {
       val vs = mutable.ArrayBuffer.empty[JValue]
       def add(s: CharSequence): Unit = { vs += JString(s.toString) }
       def add(v: JValue): Unit = { vs += v }
-      def finish: JValue = JArray(vs.toArray)
+      def finish(): JValue = JArray(vs.toArray)
       def isObj: Boolean = false
     }
 
@@ -45,7 +45,7 @@ object JawnFacade extends Facade[JValue] {
         if (key == null) { key = s.toString } else { vs(key.toString) = JString(s.toString); key = null }
       def add(v: JValue): Unit =
         { vs(key) = v; key = null }
-      def finish = JObject(vs)
-      def isObj = true
+      def finish() = JObject(vs)
+      def isObj: Boolean = true
     }
 }

--- a/ast/src/main/scala/jawn/ast/JawnFacade.scala
+++ b/ast/src/main/scala/jawn/ast/JawnFacade.scala
@@ -5,9 +5,9 @@ import scala.collection.mutable
 
 object JawnFacade extends Facade[JValue] {
 
-  final val jnull = JNull
-  final val jfalse = JFalse
-  final val jtrue = JTrue
+  final def jnull(): JValue = JNull
+  final def jfalse(): JValue = JFalse
+  final def jtrue(): JValue = JTrue
 
   final def jnum(s: CharSequence, decIndex: Int, expIndex: Int): JValue =
     if (decIndex == -1 && expIndex == -1) {

--- a/ast/src/test/scala/jawn/ParseCheck.scala
+++ b/ast/src/test/scala/jawn/ParseCheck.scala
@@ -58,7 +58,7 @@ class AstCheck extends Properties("AstCheck") {
       Claim(j1 == j2 && j1.## == j2.##)
     }
 
-  implicit val facade = JawnFacade
+  implicit val facade: Facade[JValue] = JawnFacade
 
   val percs = List(0.0, 0.2, 0.4, 0.8, 1.0)
 

--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -70,9 +70,10 @@ final class AsyncParser[J] protected[jawn] (
   protected[jawn] var streamMode: Int
 ) extends ByteBasedParser[J] {
 
-  protected[this] var line = 0
+  private[this] var _line = 0
   protected[this] var pos = 0
-  protected[this] final def newline(i: Int): Unit = { line += 1; pos = i + 1 }
+  protected[this] final def newline(i: Int): Unit = { _line += 1; pos = i + 1 }
+  protected[this] def line(): Int = _line
   protected[this] final def column(i: Int) = i - pos
 
   final def copy() =

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -64,9 +64,10 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
   private var ncurr = ch.read(ByteBuffer.wrap(curr))
   private var nnext = ch.read(ByteBuffer.wrap(next))
 
-  protected[this] var line = 0
+  private[this] var _line = 0
   private var pos = 0
-  protected[this] final def newline(i: Int): Unit = { line += 1; pos = i + 1 }
+  protected[this] final def newline(i: Int): Unit = { _line += 1; pos = i + 1 }
+  protected[this] final def line(): Int = _line
   protected[this] final def column(i: Int): Int = i - pos
 
   protected[this] final def close(): Unit = ch.close()

--- a/parser/src/main/scala/jawn/CharSequenceParser.scala
+++ b/parser/src/main/scala/jawn/CharSequenceParser.scala
@@ -6,10 +6,11 @@ package org.typelevel.jawn
  * This is similar to StringParser, but acts on character sequences.
  */
 private[jawn] final class CharSequenceParser[J](cs: CharSequence) extends SyncParser[J] with CharBasedParser[J] {
-  var line = 0
-  var offset = 0
+  private[this] var _line = 0
+  private[this] var offset = 0
   final def column(i: Int) = i - offset
-  final def newline(i: Int): Unit = { line += 1; offset = i + 1 }
+  final def newline(i: Int): Unit = { _line += 1; offset = i + 1 }
+  final def line(): Int = _line
   final def reset(i: Int): Int = i
   final def checkpoint(state: Int, i: Int, context: RawFContext[J], stack: List[RawFContext[J]]): Unit = ()
   final def at(i: Int): Char = cs.charAt(i)

--- a/parser/src/main/scala/jawn/MutableFacade.scala
+++ b/parser/src/main/scala/jawn/MutableFacade.scala
@@ -10,7 +10,7 @@ trait MutableFacade[J] extends Facade[J] {
     var value: J = _
     def add(s: CharSequence): Unit = { value = jstring(s) }
     def add(v: J): Unit = { value = v }
-    def finish: J = value
+    def finish(): J = value
     def isObj: Boolean = false
   }
 
@@ -18,7 +18,7 @@ trait MutableFacade[J] extends Facade[J] {
     val vs = mutable.ArrayBuffer.empty[J]
     def add(s: CharSequence): Unit = { vs += jstring(s) }
     def add(v: J): Unit = { vs += v }
-    def finish: J = jarray(vs)
+    def finish(): J = jarray(vs)
     def isObj: Boolean = false
   }
 
@@ -29,7 +29,7 @@ trait MutableFacade[J] extends Facade[J] {
       if (key == null) { key = s.toString } else { vs(key) = jstring(s); key = null }
     def add(v: J): Unit =
       { vs(key) = v; key = null }
-    def finish = jobject(vs)
-    def isObj = true
+    def finish() = jobject(vs)
+    def isObj: Boolean = true
   }
 }

--- a/parser/src/main/scala/jawn/NullFacade.scala
+++ b/parser/src/main/scala/jawn/NullFacade.scala
@@ -15,12 +15,12 @@ object NullFacade extends Facade[Unit] {
   case class NullContext(isObj: Boolean) extends FContext[Unit] {
     def add(s: CharSequence): Unit = ()
     def add(v: Unit): Unit = ()
-    def finish: Unit = ()
+    def finish(): Unit = ()
   }
 
-  val singleContext: RawFContext[Unit] = NullContext(false)
-  val arrayContext: RawFContext[Unit] = NullContext(false)
-  val objectContext: RawFContext[Unit] = NullContext(true)
+  def singleContext(): RawFContext[Unit] = NullContext(false)
+  def arrayContext(): RawFContext[Unit] = NullContext(false)
+  def objectContext(): RawFContext[Unit] = NullContext(true)
 
   def jnull(): Unit = ()
   def jfalse(): Unit = ()

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -165,7 +165,7 @@ abstract class Parser[J] {
       j += 1
       c = at(j)
     } else if ('1' <= c && c <= '9') {
-      do { j += 1; c = at(j) } while ('0' <= c && c <= '9')
+      while ({ j += 1; c = at(j); '0' <= c && c <= '9' }) ()
     } else {
       die(i, "expected digit")
     }
@@ -175,7 +175,7 @@ abstract class Parser[J] {
       j += 1
       c = at(j)
       if ('0' <= c && c <= '9') {
-        do { j += 1; c = at(j) } while ('0' <= c && c <= '9') 
+        while ({ j += 1; c = at(j); '0' <= c && c <= '9' }) ()
       } else {
         die(i, "expected digit")
       }
@@ -190,7 +190,7 @@ abstract class Parser[J] {
         c = at(j)
       }
       if ('0' <= c && c <= '9') {
-        do { j += 1; c = at(j) } while ('0' <= c && c <= '9')
+        while ({ j += 1; c = at(j); '0' <= c && c <= '9' }) ()
       } else {
         die(i, "expected digit")
       }
@@ -233,14 +233,15 @@ abstract class Parser[J] {
       }
       c = at(j)
     } else if ('1' <= c && c <= '9') {
-      do {
+      while ({
         j += 1
         if (atEof(j)) {
           ctxt.add(facade.jnum(at(i, j), decIndex, expIndex, i), i)
           return j
         }
         c = at(j)
-      } while ('0' <= c && c <= '9')
+        '0' <= c && c <= '9'
+      }) ()
     } else {
       die(i, "expected digit")
     }
@@ -251,14 +252,15 @@ abstract class Parser[J] {
       j += 1
       c = at(j)
       if ('0' <= c && c <= '9') {
-        do {
+        while ({
           j += 1
           if (atEof(j)) {
             ctxt.add(facade.jnum(at(i, j), decIndex, expIndex, i), i)
             return j
           }
           c = at(j)
-        } while ('0' <= c && c <= '9')
+          '0' <= c && c <= '9'
+        }) ()
       } else {
         die(i, "expected digit")
       }
@@ -274,14 +276,15 @@ abstract class Parser[J] {
         c = at(j)
       }
       if ('0' <= c && c <= '9') {
-        do {
+        while ({
           j += 1
           if (atEof(j)) {
             ctxt.add(facade.jnum(at(i, j), decIndex, expIndex, i), i)
             return j
           }
           c = at(j)
-        } while ('0' <= c && c <= '9')
+          '0' <= c && c <= '9'
+        }) ()
       } else {
         die(i, "expected digit")
       }

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -514,22 +514,22 @@ object Parser {
     new StringParser(s).parse()
 
   def parseFromString[J](s: String)(implicit facade: RawFacade[J]): Try[J] =
-    Try(new StringParser[J](s).parse)
+    Try(new StringParser[J](s).parse())
 
   def parseFromCharSequence[J](cs: CharSequence)(implicit facade: RawFacade[J]): Try[J] =
-    Try(new CharSequenceParser[J](cs).parse)
+    Try(new CharSequenceParser[J](cs).parse())
 
   def parseFromPath[J](path: String)(implicit facade: RawFacade[J]): Try[J] =
-    Try(ChannelParser.fromFile[J](new File(path)).parse)
+    Try(ChannelParser.fromFile[J](new File(path)).parse())
 
   def parseFromFile[J](file: File)(implicit facade: RawFacade[J]): Try[J] =
-    Try(ChannelParser.fromFile[J](file).parse)
+    Try(ChannelParser.fromFile[J](file).parse())
 
   def parseFromChannel[J](ch: ReadableByteChannel)(implicit facade: RawFacade[J]): Try[J] =
-    Try(ChannelParser.fromChannel[J](ch).parse)
+    Try(ChannelParser.fromChannel[J](ch).parse())
 
   def parseFromByteBuffer[J](buf: ByteBuffer)(implicit facade: RawFacade[J]): Try[J] =
-    Try(new ByteBufferParser[J](buf).parse)
+    Try(new ByteBufferParser[J](buf).parse())
 
   def async[J](mode: AsyncParser.Mode)(implicit facade: RawFacade[J]): AsyncParser[J] =
     AsyncParser[J](mode)

--- a/parser/src/main/scala/jawn/SimpleFacade.scala
+++ b/parser/src/main/scala/jawn/SimpleFacade.scala
@@ -17,7 +17,7 @@ trait SimpleFacade[J] extends Facade[J] {
     var value: J = _
     def add(s: CharSequence): Unit = { value = jstring(s) }
     def add(v: J): Unit = { value = v }
-    def finish: J = value
+    def finish(): J = value
     def isObj: Boolean = false
   }
 
@@ -25,7 +25,7 @@ trait SimpleFacade[J] extends Facade[J] {
     val vs = mutable.ListBuffer.empty[J]
     def add(s: CharSequence): Unit = { vs += jstring(s) }
     def add(v: J): Unit = { vs += v }
-    def finish: J = jarray(vs.toList)
+    def finish(): J = jarray(vs.toList)
     def isObj: Boolean = false
   }
 
@@ -36,7 +36,7 @@ trait SimpleFacade[J] extends Facade[J] {
       if (key == null) { key = s.toString } else { vs = vs.updated(key, jstring(s)); key = null }
     def add(v: J): Unit =
       { vs = vs.updated(key, v); key = null }
-    def finish = jobject(vs)
-    def isObj = true
+    def finish(): J = jobject(vs)
+    def isObj: Boolean = true
   }
 }

--- a/parser/src/main/scala/jawn/StringParser.scala
+++ b/parser/src/main/scala/jawn/StringParser.scala
@@ -13,10 +13,11 @@ package org.typelevel.jawn
  * practice.
  */
 private[jawn] final class StringParser[J](s: String) extends SyncParser[J] with CharBasedParser[J] {
-  var line = 0
-  var offset = 0
+  private[this] var _line = 0
+  private[this] var offset = 0
   final def column(i: Int) = i - offset
-  final def newline(i: Int): Unit = { line += 1; offset = i + 1 }
+  final def newline(i: Int): Unit = { _line += 1; offset = i + 1 }
+  final def line(): Int = _line
   final def reset(i: Int): Int = i
   final def checkpoint(state: Int, i: Int, context: RawFContext[J], stack: List[RawFContext[J]]): Unit = {}
   final def at(i: Int): Char = s.charAt(i)

--- a/parser/src/main/scala/jawn/SupportParser.scala
+++ b/parser/src/main/scala/jawn/SupportParser.scala
@@ -12,19 +12,19 @@ trait SupportParser[J] {
     new StringParser(s).parse()
 
   def parseFromString(s: String): Try[J] =
-    Try(new StringParser[J](s).parse)
+    Try(new StringParser[J](s).parse())
 
   def parseFromPath(path: String): Try[J] =
-    Try(ChannelParser.fromFile[J](new File(path)).parse)
+    Try(ChannelParser.fromFile[J](new File(path)).parse())
 
   def parseFromFile(file: File): Try[J] =
-    Try(ChannelParser.fromFile[J](file).parse)
+    Try(ChannelParser.fromFile[J](file).parse())
 
   def parseFromChannel(ch: ReadableByteChannel): Try[J] =
-    Try(ChannelParser.fromChannel[J](ch).parse)
+    Try(ChannelParser.fromChannel[J](ch).parse())
 
   def parseFromByteBuffer(buf: ByteBuffer): Try[J] =
-    Try(new ByteBufferParser[J](buf).parse)
+    Try(new ByteBufferParser[J](buf).parse())
 
   def async(mode: AsyncParser.Mode): AsyncParser[J] =
     AsyncParser[J](mode)

--- a/parser/src/main/scala/jawn/Syntax.scala
+++ b/parser/src/main/scala/jawn/Syntax.scala
@@ -11,17 +11,17 @@ object Syntax {
   implicit def unitFacade: RawFacade[Unit] = NullFacade
 
   def checkString(s: String): Boolean =
-    Try(new StringParser(s).parse).isSuccess
+    Try(new StringParser(s).parse()).isSuccess
 
   def checkPath(path: String): Boolean =
-    Try(ChannelParser.fromFile(new File(path)).parse).isSuccess
+    Try(ChannelParser.fromFile(new File(path)).parse()).isSuccess
 
   def checkFile(file: File): Boolean =
-    Try(ChannelParser.fromFile(file).parse).isSuccess
+    Try(ChannelParser.fromFile(file).parse()).isSuccess
 
   def checkChannel(ch: ReadableByteChannel): Boolean =
-    Try(ChannelParser.fromChannel(ch).parse).isSuccess
+    Try(ChannelParser.fromChannel(ch).parse()).isSuccess
 
   def checkByteBuffer(buf: ByteBuffer): Boolean =
-    Try(new ByteBufferParser(buf).parse).isSuccess
+    Try(new ByteBufferParser(buf).parse()).isSuccess
 }


### PR DESCRIPTION
In a couple of places I've had to change `val` to `def` but otherwise these are superficial changes. I've confirmed that `parser` and `util` compile on Dotty (without `-language:Scala2`).