### PR TITLE
Dotty cross-building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ TAGS
 .lib
 .ensime_cache
 .idea
+_site

--- a/ast/src/main/scala/jawn/ast/JParser.scala
+++ b/ast/src/main/scala/jawn/ast/JParser.scala
@@ -7,7 +7,7 @@ import java.nio.channels.ReadableByteChannel
 import scala.util.Try
 
 object JParser {
-  implicit val facade = JawnFacade
+  implicit val facade: Facade[JValue] = JawnFacade
 
   def parseUnsafe(s: String): JValue =
     new StringParser(s).parse()

--- a/ast/src/main/scala/jawn/ast/JParser.scala
+++ b/ast/src/main/scala/jawn/ast/JParser.scala
@@ -13,22 +13,22 @@ object JParser {
     new StringParser(s).parse()
 
   def parseFromString(s: String): Try[JValue] =
-    Try(new StringParser[JValue](s).parse)
+    Try(new StringParser[JValue](s).parse())
 
   def parseFromCharSequence(cs: CharSequence): Try[JValue] =
-    Try(new CharSequenceParser[JValue](cs).parse)
+    Try(new CharSequenceParser[JValue](cs).parse())
 
   def parseFromPath(path: String): Try[JValue] =
     parseFromFile(new File(path))
 
   def parseFromFile(file: File): Try[JValue] =
-    Try(ChannelParser.fromFile[JValue](file).parse)
+    Try(ChannelParser.fromFile[JValue](file).parse())
 
   def parseFromChannel(ch: ReadableByteChannel): Try[JValue] =
-    Try(ChannelParser.fromChannel(ch).parse)
+    Try(ChannelParser.fromChannel(ch).parse())
 
   def parseFromByteBuffer(buf: ByteBuffer): Try[JValue] =
-    Try(new ByteBufferParser[JValue](buf).parse)
+    Try(new ByteBufferParser[JValue](buf).parse())
 
   def async(mode: AsyncParser.Mode): AsyncParser[JValue] =
     AsyncParser(mode)

--- a/ast/src/main/scala/jawn/ast/JawnFacade.scala
+++ b/ast/src/main/scala/jawn/ast/JawnFacade.scala
@@ -5,9 +5,9 @@ import scala.collection.mutable
 
 object JawnFacade extends Facade[JValue] {
 
-  final val jnull = JNull
-  final val jfalse = JFalse
-  final val jtrue = JTrue
+  final def jnull(): JValue = JNull
+  final def jfalse(): JValue = JFalse
+  final def jtrue(): JValue = JTrue
 
   final def jnum(s: CharSequence, decIndex: Int, expIndex: Int): JValue =
     if (decIndex == -1 && expIndex == -1) {
@@ -24,7 +24,7 @@ object JawnFacade extends Facade[JValue] {
       var value: JValue = _
       def add(s: CharSequence): Unit = value = JString(s.toString)
       def add(v: JValue): Unit = value = v
-      def finish: JValue = value
+      def finish(): JValue = value
       def isObj: Boolean = false
     }
 
@@ -33,7 +33,7 @@ object JawnFacade extends Facade[JValue] {
       val vs = mutable.ArrayBuffer.empty[JValue]
       def add(s: CharSequence): Unit = vs += JString(s.toString)
       def add(v: JValue): Unit = vs += v
-      def finish: JValue = JArray(vs.toArray)
+      def finish(): JValue = JArray(vs.toArray)
       def isObj: Boolean = false
     }
 
@@ -48,7 +48,7 @@ object JawnFacade extends Facade[JValue] {
           vs(key.toString) = JString(s.toString); key = null
         }
       def add(v: JValue): Unit = { vs(key) = v; key = null }
-      def finish = JObject(vs)
-      def isObj = true
+      def finish() = JObject(vs)
+      def isObj: Boolean = true
     }
 }

--- a/ast/src/test/scala/jawn/AstTest.scala
+++ b/ast/src/test/scala/jawn/AstTest.scala
@@ -38,7 +38,7 @@ class AstTest extends Properties("AstTest") {
 
   property(".getInt") = forAll { (n: Int) =>
     Claim(
-      JNum(n).getInt == Some(n) &&
+      JNum(n.toLong).getInt == Some(n) &&
         JParser.parseUnsafe(n.toString).getInt == Some(n)
     )
   }

--- a/ast/src/test/scala/jawn/ParseCheck.scala
+++ b/ast/src/test/scala/jawn/ParseCheck.scala
@@ -59,7 +59,7 @@ class AstCheck extends Properties("AstCheck") {
     Claim(j1 == j2 && j1.## == j2.##)
   }
 
-  implicit val facade = JawnFacade
+  implicit val facade: Facade[JValue] = JawnFacade
 
   val percs = List(0.0, 0.2, 0.4, 0.8, 1.0)
 

--- a/ast/src/test/scala/jawn/ParseCheck.scala
+++ b/ast/src/test/scala/jawn/ParseCheck.scala
@@ -20,7 +20,7 @@ class AstCheck extends Properties("AstCheck") {
   // * jvalue equality
   //
   // not bad.
-  property("idempotent parsing/rendering") = forAll { value1: JValue =>
+  property("idempotent parsing/rendering") = forAll { (value1: JValue) =>
     val json1 = CanonicalRenderer.render(value1)
     val value2 = JParser.parseFromString(json1).get
     val json2 = CanonicalRenderer.render(value2)
@@ -39,7 +39,7 @@ class AstCheck extends Properties("AstCheck") {
     p0 && p1
   }
 
-  property("string encoding/decoding") = forAll { s: String =>
+  property("string encoding/decoding") = forAll { (s: String) =>
     val jstr1 = JString(s)
     val json1 = CanonicalRenderer.render(jstr1)
     val jstr2 = JParser.parseFromString(json1).get
@@ -51,7 +51,7 @@ class AstCheck extends Properties("AstCheck") {
     )
   }
 
-  property("string/charSequence parsing") = forAll { value: JValue =>
+  property("string/charSequence parsing") = forAll { (value: JValue) =>
     val s = CanonicalRenderer.render(value)
     val j1 = JParser.parseFromString(s)
     val cs = java.nio.CharBuffer.wrap(s.toCharArray)
@@ -89,7 +89,7 @@ class AstCheck extends Properties("AstCheck") {
     val data = "[1,2,3][4,5,6]"
     val p = AsyncParser[JValue](ValueStream)
     val res0 = p.absorb(data)
-    val res1 = p.finish
+    val res1 = p.finish()
     Claim(true)
   }
 
@@ -101,7 +101,7 @@ class AstCheck extends Properties("AstCheck") {
   }
 
   property("async unwrapping") = forAll { (vs0: List[Int]) =>
-    val vs = vs0.map(LongNum(_))
+    val vs = vs0.map(v0 => LongNum(v0.toLong))
     val arr = JArray(vs.toArray)
     val json = CanonicalRenderer.render(arr)
     val segments = splitIntoSegments(json)
@@ -118,8 +118,8 @@ class AstCheck extends Properties("AstCheck") {
 
   property("ignore trailing zeros") = forAll { (n: Int) =>
     val s = n.toString
-    val n1 = LongNum(n)
-    val n2 = DoubleNum(n)
+    val n1 = LongNum(n.toLong)
+    val n2 = DoubleNum(n.toDouble)
 
     def check(j: JValue): Prop =
       Claim(j == n1 && n1 == j && j == n2 && n2 == j)

--- a/build.sbt
+++ b/build.sbt
@@ -65,6 +65,7 @@ lazy val jawnSettings = Seq(
   releaseCrossBuild := true,
   publishMavenStyle := true,
   publishArtifact in Test := false,
+  publishArtifact in (Compile, packageDoc) := !isDotty.value,
   pomIncludeRepository := Function.const(false),
   publishTo := {
     val nexus = "https://oss.sonatype.org/"

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ lazy val previousJawnVersion = "0.14.0"
 lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.10"
 lazy val scala213 = "2.13.1"
+lazy val dotty = "0.21.0-RC1"
 ThisBuild / scalaVersion := scala212
 ThisBuild / organization := "org.typelevel"
 ThisBuild / licenses += ("MIT", url("http://opensource.org/licenses/MIT"))
@@ -28,15 +29,16 @@ lazy val benchmarkVersion =
   scala212
 
 lazy val jawnSettings = Seq(
-  crossScalaVersions := Seq(scala211, scala212, scala213),
+  crossScalaVersions := Seq(scala211, scala212, scala213, dotty),
   mimaPreviousArtifacts := Set(organization.value %% moduleName.value % previousJawnVersion),
   resolvers += Resolver.sonatypeRepo("releases"),
   Test / fork := true,
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "1"),
-  libraryDependencies ++=
-    "org.scalacheck" %% "scalacheck" % "1.14.3" % Test ::
-      "org.typelevel" %% "claimant" % "0.1.2" % Test ::
-      Nil,
+  libraryDependencies += ("org.scalacheck" %% "scalacheck" % "1.14.3" % Test).withDottyCompat(scalaVersion.value),
+  libraryDependencies ++= (
+    if (isDotty.value) Nil
+    else List("org.typelevel" %% "claimant" % "0.1.2" % Test)
+  ),
   scalacOptions ++=
     "-deprecation" ::
       "-encoding" :: "utf-8" ::
@@ -104,6 +106,13 @@ lazy val parser = project
   .settings(name := "parser")
   .settings(moduleName := "jawn-parser")
   .settings(jawnSettings: _*)
+  .settings(
+    Test / unmanagedSourceDirectories ++= (
+      if (isDotty.value) {
+        List(baseDirectory.value / "src" / "test" / "dotty")
+      } else Nil
+    )
+  )
   .disablePlugins(JmhPlugin)
 
 lazy val util = project
@@ -133,13 +142,13 @@ def support(s: String) =
 
 lazy val supportJson4s = support("json4s")
   .dependsOn(util)
-  .settings(libraryDependencies += "org.json4s" %% "json4s-ast" % "3.6.7")
+  .settings(libraryDependencies += ("org.json4s" %% "json4s-ast" % "3.6.7").withDottyCompat(scalaVersion.value))
 
 lazy val supportPlay = support("play")
-  .settings(libraryDependencies += "com.typesafe.play" %% "play-json" % "2.7.4")
+  .settings(libraryDependencies += ("com.typesafe.play" %% "play-json" % "2.7.4").withDottyCompat(scalaVersion.value))
 
 lazy val supportSpray = support("spray")
-  .settings(libraryDependencies += "io.spray" %% "spray-json" % "1.3.5")
+  .settings(libraryDependencies += ("io.spray" %% "spray-json" % "1.3.5").withDottyCompat(scalaVersion.value))
 
 lazy val benchmark = project
   .in(file("benchmark"))

--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -79,9 +79,10 @@ final class AsyncParser[J] protected[jawn] (
   protected[jawn] var streamMode: Int
 ) extends ByteBasedParser[J] {
 
-  protected[this] var line = 0
+  private[this] var _line = 0
   protected[this] var pos = 0
-  final protected[this] def newline(i: Int): Unit = { line += 1; pos = i + 1 }
+  final protected[this] def newline(i: Int): Unit = { _line += 1; pos = i + 1 }
+  final protected[this] def line(): Int = _line
   final protected[this] def column(i: Int) = i - pos
 
   final def copy() =

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -64,9 +64,10 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
   private var ncurr = ch.read(ByteBuffer.wrap(curr))
   private var nnext = ch.read(ByteBuffer.wrap(next))
 
-  protected[this] var line = 0
+  private[this] var _line = 0
   private var pos = 0
-  final protected[this] def newline(i: Int): Unit = { line += 1; pos = i + 1 }
+  final protected[this] def newline(i: Int): Unit = { _line += 1; pos = i + 1 }
+  final protected[this] def line(): Int = _line
   final protected[this] def column(i: Int): Int = i - pos
 
   final protected[this] def close(): Unit = ch.close()

--- a/parser/src/main/scala/jawn/CharSequenceParser.scala
+++ b/parser/src/main/scala/jawn/CharSequenceParser.scala
@@ -6,10 +6,11 @@ package org.typelevel.jawn
  * This is similar to StringParser, but acts on character sequences.
  */
 final private[jawn] class CharSequenceParser[J](cs: CharSequence) extends SyncParser[J] with CharBasedParser[J] {
-  var line = 0
-  var offset = 0
+  private[this] var _line = 0
+  private[this] var offset = 0
   final def column(i: Int) = i - offset
-  final def newline(i: Int): Unit = { line += 1; offset = i + 1 }
+  final def newline(i: Int): Unit = { _line += 1; offset = i + 1 }
+  final def line(): Int = _line
   final def reset(i: Int): Int = i
   final def checkpoint(state: Int, i: Int, context: RawFContext[J], stack: List[RawFContext[J]]): Unit = ()
   final def at(i: Int): Char = cs.charAt(i)

--- a/parser/src/main/scala/jawn/MutableFacade.scala
+++ b/parser/src/main/scala/jawn/MutableFacade.scala
@@ -10,7 +10,7 @@ trait MutableFacade[J] extends Facade[J] {
     var value: J = _
     def add(s: CharSequence): Unit = value = jstring(s)
     def add(v: J): Unit = value = v
-    def finish: J = value
+    def finish(): J = value
     def isObj: Boolean = false
   }
 
@@ -18,7 +18,7 @@ trait MutableFacade[J] extends Facade[J] {
     val vs = mutable.ArrayBuffer.empty[J]
     def add(s: CharSequence): Unit = vs += jstring(s)
     def add(v: J): Unit = vs += v
-    def finish: J = jarray(vs)
+    def finish(): J = jarray(vs)
     def isObj: Boolean = false
   }
 
@@ -32,7 +32,7 @@ trait MutableFacade[J] extends Facade[J] {
         vs(key) = jstring(s); key = null
       }
     def add(v: J): Unit = { vs(key) = v; key = null }
-    def finish = jobject(vs)
-    def isObj = true
+    def finish(): J = jobject(vs)
+    def isObj: Boolean = true
   }
 }

--- a/parser/src/main/scala/jawn/NullFacade.scala
+++ b/parser/src/main/scala/jawn/NullFacade.scala
@@ -15,12 +15,12 @@ object NullFacade extends Facade[Unit] {
   case class NullContext(isObj: Boolean) extends FContext[Unit] {
     def add(s: CharSequence): Unit = ()
     def add(v: Unit): Unit = ()
-    def finish: Unit = ()
+    def finish(): Unit = ()
   }
 
-  val singleContext: RawFContext[Unit] = NullContext(false)
-  val arrayContext: RawFContext[Unit] = NullContext(false)
-  val objectContext: RawFContext[Unit] = NullContext(true)
+  def singleContext(): RawFContext[Unit] = NullContext(false)
+  def arrayContext(): RawFContext[Unit] = NullContext(false)
+  def objectContext(): RawFContext[Unit] = NullContext(true)
 
   def jnull(): Unit = ()
   def jfalse(): Unit = ()

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -167,7 +167,7 @@ abstract class Parser[J] {
       j += 1
       c = at(j)
     } else if ('1' <= c && c <= '9') {
-      do { j += 1; c = at(j) } while ('0' <= c && c <= '9')
+      while ({ j += 1; c = at(j); '0' <= c && c <= '9' }) ()
     } else {
       die(i, "expected digit")
     }
@@ -177,7 +177,7 @@ abstract class Parser[J] {
       j += 1
       c = at(j)
       if ('0' <= c && c <= '9') {
-        do { j += 1; c = at(j) } while ('0' <= c && c <= '9')
+        while ({ j += 1; c = at(j); '0' <= c && c <= '9' }) ()
       } else {
         die(i, "expected digit")
       }
@@ -192,7 +192,7 @@ abstract class Parser[J] {
         c = at(j)
       }
       if ('0' <= c && c <= '9') {
-        do { j += 1; c = at(j) } while ('0' <= c && c <= '9')
+        while ({ j += 1; c = at(j); '0' <= c && c <= '9' }) ()
       } else {
         die(i, "expected digit")
       }
@@ -235,14 +235,15 @@ abstract class Parser[J] {
       }
       c = at(j)
     } else if ('1' <= c && c <= '9') {
-      do {
+      while ({
         j += 1
         if (atEof(j)) {
           ctxt.add(facade.jnum(at(i, j), decIndex, expIndex, i), i)
           return j
         }
         c = at(j)
-      } while ('0' <= c && c <= '9')
+        '0' <= c && c <= '9'
+      }) ()
     } else {
       die(i, "expected digit")
     }
@@ -253,14 +254,15 @@ abstract class Parser[J] {
       j += 1
       c = at(j)
       if ('0' <= c && c <= '9') {
-        do {
+        while ({
           j += 1
           if (atEof(j)) {
             ctxt.add(facade.jnum(at(i, j), decIndex, expIndex, i), i)
             return j
           }
           c = at(j)
-        } while ('0' <= c && c <= '9')
+          '0' <= c && c <= '9'
+        }) ()
       } else {
         die(i, "expected digit")
       }
@@ -276,14 +278,15 @@ abstract class Parser[J] {
         c = at(j)
       }
       if ('0' <= c && c <= '9') {
-        do {
+        while ({
           j += 1
           if (atEof(j)) {
             ctxt.add(facade.jnum(at(i, j), decIndex, expIndex, i), i)
             return j
           }
           c = at(j)
-        } while ('0' <= c && c <= '9')
+          '0' <= c && c <= '9'
+        }) ()
       } else {
         die(i, "expected digit")
       }

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -513,22 +513,22 @@ object Parser {
     new StringParser(s).parse()
 
   def parseFromString[J](s: String)(implicit facade: RawFacade[J]): Try[J] =
-    Try(new StringParser[J](s).parse)
+    Try(new StringParser[J](s).parse())
 
   def parseFromCharSequence[J](cs: CharSequence)(implicit facade: RawFacade[J]): Try[J] =
-    Try(new CharSequenceParser[J](cs).parse)
+    Try(new CharSequenceParser[J](cs).parse())
 
   def parseFromPath[J](path: String)(implicit facade: RawFacade[J]): Try[J] =
-    Try(ChannelParser.fromFile[J](new File(path)).parse)
+    Try(ChannelParser.fromFile[J](new File(path)).parse())
 
   def parseFromFile[J](file: File)(implicit facade: RawFacade[J]): Try[J] =
-    Try(ChannelParser.fromFile[J](file).parse)
+    Try(ChannelParser.fromFile[J](file).parse())
 
   def parseFromChannel[J](ch: ReadableByteChannel)(implicit facade: RawFacade[J]): Try[J] =
-    Try(ChannelParser.fromChannel[J](ch).parse)
+    Try(ChannelParser.fromChannel[J](ch).parse())
 
   def parseFromByteBuffer[J](buf: ByteBuffer)(implicit facade: RawFacade[J]): Try[J] =
-    Try(new ByteBufferParser[J](buf).parse)
+    Try(new ByteBufferParser[J](buf).parse())
 
   def parseFromByteArray[J](src: Array[Byte])(implicit facade: RawFacade[J]): Try[J] =
     Try(new ByteArrayParser[J](src).parse())

--- a/parser/src/main/scala/jawn/SimpleFacade.scala
+++ b/parser/src/main/scala/jawn/SimpleFacade.scala
@@ -17,7 +17,7 @@ trait SimpleFacade[J] extends Facade[J] {
     var value: J = _
     def add(s: CharSequence): Unit = value = jstring(s)
     def add(v: J): Unit = value = v
-    def finish: J = value
+    def finish(): J = value
     def isObj: Boolean = false
   }
 
@@ -25,7 +25,7 @@ trait SimpleFacade[J] extends Facade[J] {
     val vs = mutable.ListBuffer.empty[J]
     def add(s: CharSequence): Unit = vs += jstring(s)
     def add(v: J): Unit = vs += v
-    def finish: J = jarray(vs.toList)
+    def finish(): J = jarray(vs.toList)
     def isObj: Boolean = false
   }
 
@@ -39,7 +39,7 @@ trait SimpleFacade[J] extends Facade[J] {
         vs = vs.updated(key, jstring(s)); key = null
       }
     def add(v: J): Unit = { vs = vs.updated(key, v); key = null }
-    def finish = jobject(vs)
-    def isObj = true
+    def finish(): J = jobject(vs)
+    def isObj: Boolean = true
   }
 }

--- a/parser/src/main/scala/jawn/StringParser.scala
+++ b/parser/src/main/scala/jawn/StringParser.scala
@@ -13,10 +13,11 @@ package org.typelevel.jawn
  * practice.
  */
 final private[jawn] class StringParser[J](s: String) extends SyncParser[J] with CharBasedParser[J] {
-  var line = 0
-  var offset = 0
+  private[this] var _line = 0
+  private[this] var offset = 0
   final def column(i: Int) = i - offset
-  final def newline(i: Int): Unit = { line += 1; offset = i + 1 }
+  final def newline(i: Int): Unit = { _line += 1; offset = i + 1 }
+  final def line(): Int = _line
   final def reset(i: Int): Int = i
   final def checkpoint(state: Int, i: Int, context: RawFContext[J], stack: List[RawFContext[J]]): Unit = {}
   final def at(i: Int): Char = s.charAt(i)

--- a/parser/src/main/scala/jawn/SupportParser.scala
+++ b/parser/src/main/scala/jawn/SupportParser.scala
@@ -12,19 +12,19 @@ trait SupportParser[J] {
     new StringParser(s).parse()
 
   def parseFromString(s: String): Try[J] =
-    Try(new StringParser[J](s).parse)
+    Try(new StringParser[J](s).parse())
 
   def parseFromPath(path: String): Try[J] =
-    Try(ChannelParser.fromFile[J](new File(path)).parse)
+    Try(ChannelParser.fromFile[J](new File(path)).parse())
 
   def parseFromFile(file: File): Try[J] =
-    Try(ChannelParser.fromFile[J](file).parse)
+    Try(ChannelParser.fromFile[J](file).parse())
 
   def parseFromChannel(ch: ReadableByteChannel): Try[J] =
-    Try(ChannelParser.fromChannel[J](ch).parse)
+    Try(ChannelParser.fromChannel[J](ch).parse())
 
   def parseFromByteBuffer(buf: ByteBuffer): Try[J] =
-    Try(new ByteBufferParser[J](buf).parse)
+    Try(new ByteBufferParser[J](buf).parse())
 
   def parseFromByteArray(src: Array[Byte]): Try[J] =
     Try(new ByteArrayParser[J](src).parse())

--- a/parser/src/main/scala/jawn/Syntax.scala
+++ b/parser/src/main/scala/jawn/Syntax.scala
@@ -9,17 +9,17 @@ object Syntax {
   implicit def unitFacade: RawFacade[Unit] = NullFacade
 
   def checkString(s: String): Boolean =
-    Try(new StringParser(s).parse).isSuccess
+    Try(new StringParser(s).parse()).isSuccess
 
   def checkPath(path: String): Boolean =
-    Try(ChannelParser.fromFile(new File(path)).parse).isSuccess
+    Try(ChannelParser.fromFile(new File(path)).parse()).isSuccess
 
   def checkFile(file: File): Boolean =
-    Try(ChannelParser.fromFile(file).parse).isSuccess
+    Try(ChannelParser.fromFile(file).parse()).isSuccess
 
   def checkChannel(ch: ReadableByteChannel): Boolean =
-    Try(ChannelParser.fromChannel(ch).parse).isSuccess
+    Try(ChannelParser.fromChannel(ch).parse()).isSuccess
 
   def checkByteBuffer(buf: ByteBuffer): Boolean =
-    Try(new ByteBufferParser(buf).parse).isSuccess
+    Try(new ByteBufferParser(buf).parse()).isSuccess
 }

--- a/parser/src/test/dotty/org/typelevel/claimant/Claim.scala
+++ b/parser/src/test/dotty/org/typelevel/claimant/Claim.scala
@@ -1,0 +1,10 @@
+package org.typelevel.claimant
+
+import org.scalacheck.Prop
+
+/**
+ * A vastly simplified, macro-free version of Claimant for Dotty.
+ */
+object Claim {
+  def apply(cond: Boolean): Prop = Prop(cond)
+}

--- a/parser/src/test/scala/jawn/JNumIndexCheck.scala
+++ b/parser/src/test/scala/jawn/JNumIndexCheck.scala
@@ -15,12 +15,12 @@ class JNumIndexCheck extends Properties("JNumIndexCheck") {
       def add(s: CharSequence): Unit = ()
       def add(v: Boolean): Unit =
         if (!v) failed = true
-      def finish: Boolean = !failed
+      def finish(): Boolean = !failed
     }
 
-    val singleContext: RawFContext[Boolean] = new JNumIndexCheckContext(false)
-    val arrayContext: RawFContext[Boolean] = new JNumIndexCheckContext(false)
-    val objectContext: RawFContext[Boolean] = new JNumIndexCheckContext(true)
+    def singleContext(): RawFContext[Boolean] = new JNumIndexCheckContext(false)
+    def arrayContext(): RawFContext[Boolean] = new JNumIndexCheckContext(false)
+    def objectContext(): RawFContext[Boolean] = new JNumIndexCheckContext(true)
 
     def jnull(): Boolean = true
     def jfalse(): Boolean = true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.4")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")

--- a/support/json4s/src/main/scala/Parser.scala
+++ b/support/json4s/src/main/scala/Parser.scala
@@ -30,7 +30,7 @@ class Parser(useBigDecimalForDouble: Boolean, useBigIntForLong: Boolean) extends
           var value: JValue = null
           def add(s: CharSequence): Unit = value = jstring(s)
           def add(v: JValue): Unit = value = v
-          def finish: JValue = value
+          def finish(): JValue = value
           def isObj: Boolean = false
         }
 
@@ -39,7 +39,7 @@ class Parser(useBigDecimalForDouble: Boolean, useBigIntForLong: Boolean) extends
           val vs = mutable.ListBuffer.empty[JValue]
           def add(s: CharSequence): Unit = vs += jstring(s)
           def add(v: JValue): Unit = vs += v
-          def finish: JValue = JArray(vs.toList)
+          def finish(): JValue = JArray(vs.toList)
           def isObj: Boolean = false
         }
 
@@ -53,7 +53,7 @@ class Parser(useBigDecimalForDouble: Boolean, useBigIntForLong: Boolean) extends
               vs += JField(key, jstring(s)); key = null
             }
           def add(v: JValue): Unit = { vs += JField(key, v); key = null }
-          def finish: JValue = JObject(vs.toList)
+          def finish(): JValue = JObject(vs.toList)
           def isObj: Boolean = true
         }
     }


### PR DESCRIPTION
This supersedes #212, which needed a big merge after #210 anyway.

It includes the changes from #212, but actually adds Dotty cross-building as well.

There are two small complications:
* The first is that [Claimant](https://github.com/typelevel/claimant) is pretty much nothing more than a set of Scala 2 macros, which means we can't use it for testing in Dotty. I worked around this by adding some Dotty-specific testing code that implements the Claimant interface we use here (just `org.typelevel.claimant.Claim.apply`). This doesn't give nice error messages, of course, but it works, and we'll still get good messages from the Scala 2 tests. Eventually I guess we should see whether we can write Claimant using Dotty's macros, but I haven't looked into this, and don't think it should block Dotty cross-building here.
* `sbt +publishLocal` was failing on Dotty because of what seem like collisions between modules in Dottydoc. I've [asked about this](https://gitter.im/lampepfl/dotty?at=5e15a21555975518903f77b7), and there's probably a fix. In the meantime I've [followed ScalaCheck](https://github.com/lampepfl/dotty/issues/7326) in disabling `packageDoc` publishing for Dotty for now.

Note that we don't even need `-language:Scala2` here.