### PR TITLE
Drop Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,6 @@ import ReleaseTransformations._
 
 lazy val previousJawnVersion = "0.14.0"
 
-lazy val scala211 = "2.11.12"
 lazy val scala212 = "2.12.10"
 lazy val scala213 = "2.13.1"
 lazy val dotty = "0.21.0-RC1"
@@ -29,7 +28,7 @@ lazy val benchmarkVersion =
   scala212
 
 lazy val jawnSettings = Seq(
-  crossScalaVersions := Seq(scala211, scala212, scala213, dotty),
+  crossScalaVersions := Seq(scala212, scala213, dotty),
   mimaPreviousArtifacts := Set(organization.value %% moduleName.value % previousJawnVersion),
   resolvers += Resolver.sonatypeRepo("releases"),
   Test / fork := true,


### PR DESCRIPTION
As suggested by @rossabaker in #216, since play-json has dropped 2.11 in 2.8.0. Quoting my comment there:

> Some numbers: jawn-parser_2.11 had 34,207 downloads last month, with only 199 for the latest 0.14.3. That's vs. 141,725 for jawn-parser_2.12 and 218,283 for circe-jawn_2.12.

I think we should do this before 1.0.0 (personally I have zero interest in maintaining 2.11 support for the life of 1.0).