### PR TITLE
Parser.async doesn't need a facade

### DIFF
--- a/ast/src/test/scala/jawn/AstTest.scala
+++ b/ast/src/test/scala/jawn/AstTest.scala
@@ -3,7 +3,6 @@ package ast
 
 import org.scalacheck.{Prop, Properties}
 import org.typelevel.claimant.Claim
-import scala.collection.mutable
 import scala.util.{Success, Try}
 
 import ArbitraryUtil._

--- a/ast/src/test/scala/jawn/ParseCheck.scala
+++ b/ast/src/test/scala/jawn/ParseCheck.scala
@@ -1,13 +1,11 @@
 package org.typelevel.jawn
 package ast
 
-import org.scalacheck.{Arbitrary, Gen, Prop, Properties}
+import org.scalacheck.{Prop, Properties}
 import org.typelevel.claimant.Claim
 import org.typelevel.jawn.parser.TestUtil
-import scala.collection.mutable
-import scala.util.{Success, Try}
+import scala.util.Success
 
-import Arbitrary.arbitrary
 import ArbitraryUtil._
 import Prop.forAll
 
@@ -88,8 +86,8 @@ class AstCheck extends Properties("AstCheck") {
   property("async multi") = {
     val data = "[1,2,3][4,5,6]"
     val p = AsyncParser[JValue](ValueStream)
-    val res0 = p.absorb(data)
-    val res1 = p.finish()
+    p.absorb(data)
+    p.finish()
     Claim(true)
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val jawnSettings = Seq(
       "-encoding" :: "utf-8" ::
       "-feature" ::
       "-unchecked" ::
+      "-Xlint" ::
       Nil,
   scalacOptions ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {

--- a/parser/src/main/scala/jawn/Parser.scala
+++ b/parser/src/main/scala/jawn/Parser.scala
@@ -533,8 +533,7 @@ object Parser {
   def parseFromByteArray[J](src: Array[Byte])(implicit facade: RawFacade[J]): Try[J] =
     Try(new ByteArrayParser[J](src).parse())
 
-  def async[J](mode: AsyncParser.Mode)(implicit facade: RawFacade[J]): AsyncParser[J] =
-    AsyncParser[J](mode)
+  def async[J](mode: AsyncParser.Mode): AsyncParser[J] = AsyncParser[J](mode)
 
   /**
    * Private variables.

--- a/parser/src/test/scala/jawn/ChannelSpec.scala
+++ b/parser/src/test/scala/jawn/ChannelSpec.scala
@@ -1,10 +1,8 @@
 package org.typelevel.jawn
 package parser
 
-import java.nio.channels.ByteChannel
 import org.scalacheck.Properties
 import org.typelevel.claimant.Claim
-import scala.util.Success
 
 class ChannelSpec extends Properties("ChannelSpec") {
 

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -251,7 +251,7 @@ class SyntaxCheck extends Properties("SyntaxCheck") {
     extract1(Parser.parseFromCharSequence(json)(NullFacade)) &&
     extract1(Parser.parseFromChannel(ch(json))(NullFacade)) &&
     extract1(Parser.parseFromByteBuffer(bb(json))(NullFacade)) &&
-    extract2(Parser.async(AsyncParser.UnwrapArray)(NullFacade).finalAbsorb(json)(NullFacade))
+    extract2(Parser.async(AsyncParser.UnwrapArray).finalAbsorb(json)(NullFacade))
   }
 
   property("error location 1") = { testErrorLoc("[1, 2,\nx3]", 2, 1) }

--- a/parser/src/test/scala/jawn/SyntaxCheck.scala
+++ b/parser/src/test/scala/jawn/SyntaxCheck.scala
@@ -6,7 +6,6 @@ import org.scalacheck.{Arbitrary, Gen, Prop, Properties}
 import org.typelevel.claimant.Claim
 import scala.util.{Failure, Success, Try}
 
-import Arbitrary.arbitrary
 import Prop.forAll
 
 class SyntaxCheck extends Properties("SyntaxCheck") {

--- a/util/src/test/scala/jawn/util/ParseLongCheck.scala
+++ b/util/src/test/scala/jawn/util/ParseLongCheck.scala
@@ -1,11 +1,10 @@
 package org.typelevel.jawn
 package util
 
-import org.scalacheck.{Arbitrary, Gen, Prop, Properties, Test}
+import org.scalacheck.{Arbitrary, Gen, Prop, Properties}
 import org.typelevel.claimant.Claim
 import scala.util.{Failure, Success, Try}
 
-import Arbitrary.arbitrary
 import Prop.forAll
 
 class ParseLongCheck extends Properties("ParseLongCheck") {


### PR DESCRIPTION
Constructing an `AsyncParser` doesn't require a facade—only feeding it. This unused parameter was the only thing keeping us from enabling `-Xlint`, and since it's a breaking change we should do it now.