### PR TITLE
Use TreeMap for jawn-ast

### DIFF
--- a/ast/src/main/scala/jawn/ast/JValue.scala
+++ b/ast/src/main/scala/jawn/ast/JValue.scala
@@ -307,10 +307,10 @@ case class JObject(vs: mutable.Map[String, JValue]) extends JValue {
 
 object JObject { self =>
   final def empty: JObject =
-    JObject(mutable.Map.empty)
+    JObject(mutable.TreeMap.empty)
 
   final def fromSeq(js: collection.Seq[(String, JValue)]): JObject = {
-    val builder = mutable.Map.newBuilder[String, JValue]
+    val builder = mutable.TreeMap.newBuilder[String, JValue]
     builder ++= js
     JObject(builder.result)
   }

--- a/ast/src/main/scala/jawn/ast/JawnFacade.scala
+++ b/ast/src/main/scala/jawn/ast/JawnFacade.scala
@@ -40,7 +40,7 @@ object JawnFacade extends Facade[JValue] {
   final def objectContext(): RawFContext[JValue] =
     new FContext[JValue] {
       var key: String = null
-      val vs = mutable.Map.empty[String, JValue]
+      val vs = mutable.TreeMap.empty[String, JValue]
       def add(s: CharSequence): Unit =
         if (key == null) {
           key = s.toString


### PR DESCRIPTION
I'm guessing this will fix #220 (possibly at the expense of some runtime performance for normal usage)? Personally I'm not really worried about this, because 1) I don't think anyone uses jawn-ast, and 2) this isn't a Jawn-specific issue—it's something anyone who uses the default Scala `mutable.Map` implementation will run into.

Update: yeah, looks fine:

```
[info] Benchmark                                  (size)   Mode  Cnt        Score   Error  Units
[info] ExtractFieldsReading.jawnByteBufferParser       1  thrpt       1391509.930          ops/s
[info] ExtractFieldsReading.jawnByteBufferParser      10  thrpt        194867.014          ops/s
[info] ExtractFieldsReading.jawnByteBufferParser     100  thrpt         18614.089          ops/s
[info] ExtractFieldsReading.jawnByteBufferParser    1000  thrpt          1697.312          ops/s
[info] ExtractFieldsReading.jawnByteBufferParser   10000  thrpt           134.183          ops/s
[info] ExtractFieldsReading.jawnByteBufferParser  100000  thrpt            10.700          ops/s
[info] ExtractFieldsReading.jawnJsoniterScala          1  thrpt       2748019.442          ops/s
[info] ExtractFieldsReading.jawnJsoniterScala         10  thrpt        328586.019          ops/s
[info] ExtractFieldsReading.jawnJsoniterScala        100  thrpt         23315.509          ops/s
[info] ExtractFieldsReading.jawnJsoniterScala       1000  thrpt          1849.461          ops/s
[info] ExtractFieldsReading.jawnJsoniterScala      10000  thrpt           160.608          ops/s
[info] ExtractFieldsReading.jawnJsoniterScala     100000  thrpt            12.042          ops/s
[info] ExtractFieldsReading.jawnStringParser           1  thrpt       2173079.029          ops/s
[info] ExtractFieldsReading.jawnStringParser          10  thrpt        316116.383          ops/s
[info] ExtractFieldsReading.jawnStringParser         100  thrpt         28768.934          ops/s
[info] ExtractFieldsReading.jawnStringParser        1000  thrpt          2300.159          ops/s
[info] ExtractFieldsReading.jawnStringParser       10000  thrpt           172.881          ops/s
[info] ExtractFieldsReading.jawnStringParser      100000  thrpt            13.469          ops/s
```