### PR TITLE
Add parseFromCharSequence to SupportParser

### DIFF
--- a/parser/src/main/scala/jawn/SupportParser.scala
+++ b/parser/src/main/scala/jawn/SupportParser.scala
@@ -14,6 +14,9 @@ trait SupportParser[J] {
   def parseFromString(s: String): Try[J] =
     Try(new StringParser[J](s).parse())
 
+  def parseFromCharSequence(cs: CharSequence): Try[J] =
+    Try(new CharSequenceParser[J](cs).parse())
+
   def parseFromPath(path: String): Try[J] =
     Try(ChannelParser.fromFile[J](new File(path)).parse())
 


### PR DESCRIPTION
This is a minor change that I think we can sneak into 1.0.0 without resetting the RC clock.

The `SupportParser` and `Parser` companion object APIs have matching (but not identical, since the `Parser` ones take the `Facade` implicitly) `parseFromX` methods —except for this one, which was only on `Parser`. Adding it here makes the APIs match.

This should have tests but `SupportParser` is currently totally untested and this is a trivial enough addition that I don't feel responsible for going through and adding tests for all of this stuff.