### PR TITLE
Add type annotations and access modifiers

### DIFF
--- a/parser/src/main/scala/jawn/AsyncParser.scala
+++ b/parser/src/main/scala/jawn/AsyncParser.scala
@@ -83,9 +83,9 @@ final class AsyncParser[J] protected[jawn] (
   protected[this] var pos = 0
   final protected[this] def newline(i: Int): Unit = { _line += 1; pos = i + 1 }
   final protected[this] def line(): Int = _line
-  final protected[this] def column(i: Int) = i - pos
+  final protected[this] def column(i: Int): Int = i - pos
 
-  final def copy() =
+  final def copy(): AsyncParser[J] =
     new AsyncParser(state, curr, context, stack, data.clone, len, allocated, offset, done, streamMode)
 
   final def absorb(buf: ByteBuffer)(implicit facade: Facade[J]): Either[ParseException, collection.Seq[J]] = {

--- a/parser/src/main/scala/jawn/ByteArrayParser.scala
+++ b/parser/src/main/scala/jawn/ByteArrayParser.scala
@@ -9,7 +9,7 @@ final class ByteArrayParser[J](src: Array[Byte]) extends SyncParser[J] with Byte
   protected[this] def line(): Int = lineState
 
   final protected[this] def newline(i: Int): Unit = { lineState += 1; offset = i + 1 }
-  final protected[this] def column(i: Int) = i - offset
+  final protected[this] def column(i: Int): Int = i - offset
 
   final protected[this] def close(): Unit = ()
   final protected[this] def reset(i: Int): Int = i
@@ -25,5 +25,5 @@ final class ByteArrayParser[J](src: Array[Byte]) extends SyncParser[J] with Byte
   final protected[this] def at(i: Int, k: Int): CharSequence =
     new String(src, i, k - i, utf8)
 
-  final protected[this] def atEof(i: Int) = i >= src.length
+  final protected[this] def atEof(i: Int): Boolean = i >= src.length
 }

--- a/parser/src/main/scala/jawn/ByteBufferParser.scala
+++ b/parser/src/main/scala/jawn/ByteBufferParser.scala
@@ -21,7 +21,7 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
   protected[this] def line(): Int = lineState
 
   final protected[this] def newline(i: Int): Unit = { lineState += 1; offset = i + 1 }
-  final protected[this] def column(i: Int) = i - offset
+  final protected[this] def column(i: Int): Int = i - offset
 
   final protected[this] def close(): Unit = (src: Buffer).position(src.limit)
   final protected[this] def reset(i: Int): Int = i
@@ -43,5 +43,5 @@ final class ByteBufferParser[J](src: ByteBuffer) extends SyncParser[J] with Byte
     new String(arr, utf8)
   }
 
-  final protected[this] def atEof(i: Int) = i >= limit
+  final protected[this] def atEof(i: Int): Boolean = i >= limit
 }

--- a/parser/src/main/scala/jawn/ChannelParser.scala
+++ b/parser/src/main/scala/jawn/ChannelParser.scala
@@ -57,15 +57,15 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
   private[this] var Allsize: Int = Bufsize * 2
 
   // these are the actual byte arrays we'll use
-  private var curr = new Array[Byte](Bufsize)
-  private var next = new Array[Byte](Bufsize)
+  private[this] var curr = new Array[Byte](Bufsize)
+  private[this] var next = new Array[Byte](Bufsize)
 
   // these are the bytecounts for each array
-  private var ncurr = ch.read(ByteBuffer.wrap(curr))
-  private var nnext = ch.read(ByteBuffer.wrap(next))
+  private[this] var ncurr = ch.read(ByteBuffer.wrap(curr))
+  private[this] var nnext = ch.read(ByteBuffer.wrap(next))
 
   private[this] var _line = 0
-  private var pos = 0
+  private[this] var pos = 0
   final protected[this] def newline(i: Int): Unit = { _line += 1; pos = i + 1 }
   final protected[this] def line(): Int = _line
   final protected[this] def column(i: Int): Int = i - pos
@@ -165,7 +165,7 @@ final class ChannelParser[J](ch: ReadableByteChannel, bufferSize: Int) extends S
     }
   }
 
-  final protected[this] def atEof(i: Int) =
+  final protected[this] def atEof(i: Int): Boolean =
     if (i < Bufsize) i >= ncurr
     else i >= (nnext + Bufsize)
 }

--- a/parser/src/main/scala/jawn/CharSequenceParser.scala
+++ b/parser/src/main/scala/jawn/CharSequenceParser.scala
@@ -8,13 +8,13 @@ package org.typelevel.jawn
 final private[jawn] class CharSequenceParser[J](cs: CharSequence) extends SyncParser[J] with CharBasedParser[J] {
   private[this] var _line = 0
   private[this] var offset = 0
-  final def column(i: Int) = i - offset
-  final def newline(i: Int): Unit = { _line += 1; offset = i + 1 }
-  final def line(): Int = _line
-  final def reset(i: Int): Int = i
-  final def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]): Unit = ()
-  final def at(i: Int): Char = cs.charAt(i)
-  final def at(i: Int, j: Int): CharSequence = cs.subSequence(i, j)
-  final def atEof(i: Int) = i == cs.length
-  final def close() = ()
+  final protected[this] def column(i: Int): Int = i - offset
+  final protected[this] def newline(i: Int): Unit = { _line += 1; offset = i + 1 }
+  final protected[this] def line(): Int = _line
+  final protected[this] def reset(i: Int): Int = i
+  final protected[this] def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]): Unit = ()
+  final protected[this] def at(i: Int): Char = cs.charAt(i)
+  final protected[this] def at(i: Int, j: Int): CharSequence = cs.subSequence(i, j)
+  final protected[this] def atEof(i: Int): Boolean = i == cs.length
+  final protected[this] def close(): Unit = ()
 }

--- a/parser/src/main/scala/jawn/Facade.scala
+++ b/parser/src/main/scala/jawn/Facade.scala
@@ -44,7 +44,7 @@ object Facade {
     final def jnull(index: Int): J = jnull
     final def jfalse(index: Int): J = jfalse
     final def jtrue(index: Int): J = jtrue
-    final def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int) =
+    final def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): J =
       jnum(s, decIndex, expIndex)
     final def jstring(s: CharSequence, index: Int): J = jstring(s)
   }

--- a/parser/src/main/scala/jawn/StringParser.scala
+++ b/parser/src/main/scala/jawn/StringParser.scala
@@ -15,13 +15,13 @@ package org.typelevel.jawn
 final private[jawn] class StringParser[J](s: String) extends SyncParser[J] with CharBasedParser[J] {
   private[this] var _line = 0
   private[this] var offset = 0
-  final def column(i: Int) = i - offset
-  final def newline(i: Int): Unit = { _line += 1; offset = i + 1 }
-  final def line(): Int = _line
-  final def reset(i: Int): Int = i
-  final def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]): Unit = {}
-  final def at(i: Int): Char = s.charAt(i)
-  final def at(i: Int, j: Int): CharSequence = s.substring(i, j)
-  final def atEof(i: Int) = i == s.length
-  final def close() = ()
+  final protected[this] def column(i: Int): Int = i - offset
+  final protected[this] def newline(i: Int): Unit = { _line += 1; offset = i + 1 }
+  final protected[this] def line(): Int = _line
+  final protected[this] def reset(i: Int): Int = i
+  final protected[this] def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]): Unit = {}
+  final protected[this] def at(i: Int): Char = s.charAt(i)
+  final protected[this] def at(i: Int, j: Int): CharSequence = s.substring(i, j)
+  final protected[this] def atEof(i: Int): Boolean = i == s.length
+  final protected[this] def close(): Unit = ()
 }


### PR DESCRIPTION
One more minor set of changes before 1.0.0.

* In `AsyncParser`, `ByteArrayParser`, and `ByteBufferParser`, and `Facade`, all I've done is add type annotations to public methods, for clarity.
* In `ChannelParser` I've added `[this]` to some `private var` declarations so that the compiler knows that it can just use a field without an accessor (and for consistency with other private vars there).
* In `StringParser` and `CharSequenceParser` I've added access modifiers to make some method implementations match the ones in `Parser`. Both of these classes are `private[jawn]`, so this will not have any effect on Scala code, but at the JVM level they're public, so these methods would be part of their public interface without this change.