### PR TITLE
Implement end indexes for char sequences

### DIFF
--- a/parser/src/main/scala/jawn/ByteBasedParser.scala
+++ b/parser/src/main/scala/jawn/ByteBasedParser.scala
@@ -45,7 +45,7 @@ trait ByteBasedParser[J] extends Parser[J] {
   final protected[this] def parseString(i: Int, ctxt: FContext[J]): Int = {
     val k = parseStringSimple(i + 1, ctxt)
     if (k != -1) {
-      ctxt.add(at(i + 1, k - 1), i)
+      ctxt.add(at(i + 1, k - 1), i, k)
       return k
     }
 
@@ -100,7 +100,8 @@ trait ByteBasedParser[J] extends Parser[J] {
         die(j, "invalid UTF-8 encoding")
       c = byte(j) & 0xff
     }
-    ctxt.add(sb.toString, i)
-    j + 1
+    j += 1
+    ctxt.add(sb.toString, i, j)
+    j
   }
 }

--- a/parser/src/main/scala/jawn/CharBasedParser.scala
+++ b/parser/src/main/scala/jawn/CharBasedParser.scala
@@ -78,8 +78,9 @@ trait CharBasedParser[J] extends Parser[J] {
       j = reset(j)
       c = at(j)
     }
-    ctxt.add(sb.toString, i)
-    j + 1
+    j += 1
+    ctxt.add(sb.toString, i, j)
+    j
   }
 
   /**
@@ -93,7 +94,7 @@ trait CharBasedParser[J] extends Parser[J] {
   final protected[this] def parseString(i: Int, ctxt: FContext[J]): Int = {
     val k = parseStringSimple(i + 1, ctxt)
     if (k != -1) {
-      ctxt.add(at(i + 1, k - 1), i)
+      ctxt.add(at(i + 1, k - 1), i, k)
       k
     } else
       parseStringComplex(i, ctxt)

--- a/parser/src/main/scala/jawn/FContext.scala
+++ b/parser/src/main/scala/jawn/FContext.scala
@@ -9,7 +9,7 @@ package org.typelevel.jawn
  */
 trait FContext[J] {
   def add(s: CharSequence, index: Int): Unit
-  def add(s: CharSequence, startIndex: Int, endIndex: Int): Unit = add(s, startIndex)
+  def add(s: CharSequence, start: Int, limit: Int): Unit = add(s, start)
   def add(v: J, index: Int): Unit
   def finish(index: Int): J
   def isObj: Boolean

--- a/parser/src/main/scala/jawn/FContext.scala
+++ b/parser/src/main/scala/jawn/FContext.scala
@@ -9,6 +9,7 @@ package org.typelevel.jawn
  */
 trait FContext[J] {
   def add(s: CharSequence, index: Int): Unit
+  def add(s: CharSequence, startIndex: Int, endIndex: Int): Unit = add(s, startIndex)
   def add(v: J, index: Int): Unit
   def finish(index: Int): J
   def isObj: Boolean

--- a/parser/src/main/scala/jawn/Facade.scala
+++ b/parser/src/main/scala/jawn/Facade.scala
@@ -19,7 +19,7 @@ trait Facade[J] {
   def jtrue(index: Int): J
   def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): J
   def jstring(s: CharSequence, index: Int): J
-  def jstring(s: CharSequence, startIndex: Int, endIndex: Int): J = jstring(s, startIndex)
+  def jstring(s: CharSequence, start: Int, limit: Int): J = jstring(s, start)
 }
 
 object Facade {
@@ -48,7 +48,7 @@ object Facade {
     final def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): J =
       jnum(s, decIndex, expIndex)
     final def jstring(s: CharSequence, index: Int): J = jstring(s)
-    final override def jstring(s: CharSequence, startIndex: Int, endIndex: Int): J = jstring(s)
+    final override def jstring(s: CharSequence, start: Int, limit: Int): J = jstring(s)
   }
 
   /**

--- a/parser/src/main/scala/jawn/Facade.scala
+++ b/parser/src/main/scala/jawn/Facade.scala
@@ -19,6 +19,7 @@ trait Facade[J] {
   def jtrue(index: Int): J
   def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): J
   def jstring(s: CharSequence, index: Int): J
+  def jstring(s: CharSequence, startIndex: Int, endIndex: Int): J = jstring(s, startIndex)
 }
 
 object Facade {
@@ -47,6 +48,7 @@ object Facade {
     final def jnum(s: CharSequence, decIndex: Int, expIndex: Int, index: Int): J =
       jnum(s, decIndex, expIndex)
     final def jstring(s: CharSequence, index: Int): J = jstring(s)
+    final override def jstring(s: CharSequence, startIndex: Int, endIndex: Int): J = jstring(s)
   }
 
   /**


### PR DESCRIPTION
This is a PR for https://github.com/typelevel/jawn/issues/267

It allows custom parsers to access the length of the string pre-unescaping. This is necessary for accurately reporting locations of errors.