### PR TITLE
Use TreeMap in SimpleFacade to solve DoS vuln

### DIFF
--- a/parser/shared/src/main/scala/jawn/Facade.scala
+++ b/parser/shared/src/main/scala/jawn/Facade.scala
@@ -2,6 +2,8 @@ package org.typelevel.jawn
 
 import scala.collection.mutable
 import scala.collection.immutable.TreeMap
+import scala.collection.JavaConverters._
+import java.util.HashMap
 
 /**
  * [[Facade]] is a type class that describes how Jawn should construct
@@ -122,7 +124,7 @@ object Facade {
     final def objectContext(): FContext[J] =
       new FContext.NoIndexFContext[J] {
         private[this] var key: String = null
-        private[this] val vs = mutable.Map.empty[String, J]
+        private[this] val vs = (new HashMap[String, J]).asScala
         def add(s: CharSequence): Unit =
           if (key == null)
             key = s.toString

--- a/parser/shared/src/main/scala/jawn/Facade.scala
+++ b/parser/shared/src/main/scala/jawn/Facade.scala
@@ -1,6 +1,7 @@
 package org.typelevel.jawn
 
 import scala.collection.mutable
+import scala.collection.immutable.TreeMap
 
 /**
  * [[Facade]] is a type class that describes how Jawn should construct
@@ -79,7 +80,7 @@ object Facade {
     final def objectContext(): FContext[J] =
       new FContext.NoIndexFContext[J] {
         private[this] var key: String = null
-        private[this] var vs = Map.empty[String, J]
+        private[this] var vs = TreeMap.empty[String, J]
         def add(s: CharSequence): Unit =
           if (key == null)
             key = s.toString


### PR DESCRIPTION
Scala's default `Map` is vulnerable to a DoS attack where an attacker basically fills up one leaf of the hash trie and causes resource exhaustion as more elements are added to the leaf with poor efficiency. 
https://github.com/scala/bug/issues/11203

`SimpleFacade` should be resistant to this as a "simple" implementation. Users can always implement their own `Facade` if they trust the input and need the performance edge.
Switching to `TreeMap` should solve this without any compatibility issues.