### PR TITLE
Set name for root level project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,6 +39,9 @@ lazy val jawnSettingsNative = Seq(
 
 lazy val root = tlCrossRootProject
   .aggregate(parser, util, ast, benchmark)
+  .settings(
+    name := "jawn-root"
+  )
 
 lazy val parser = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Full)


### PR DESCRIPTION
QOL change, but naming the root project means that in IDE's such as Intellij you can actually tell what the project is when navigating through windows, i.e. with current name of `root` you have this

![image](https://user-images.githubusercontent.com/2337269/235292320-7d99d30c-d4cc-4489-ab8a-37ee705a2b6c.png)

This has zero effect on project since the root sbt module is not published