### PR TITLE
Properly handle index-out-of-bounds on JS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,12 +22,6 @@ lazy val jawnSettings = Seq(
 lazy val jawnSettingsJVM = List(Test / fork := true)
 lazy val jawnSettingsJS = List(
   tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "1.2.0").toMap,
-  scalaJSLinkerConfig ~= {
-    _.withSemantics(
-      _.withAsInstanceOfs(org.scalajs.linker.interface.CheckedBehavior.Unchecked)
-        .withArrayIndexOutOfBounds(org.scalajs.linker.interface.CheckedBehavior.Unchecked)
-    )
-  }
 )
 lazy val jawnSettingsNative = Seq(
   tlVersionIntroduced := Map(

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ lazy val jawnSettings = Seq(
 
 lazy val jawnSettingsJVM = List(Test / fork := true)
 lazy val jawnSettingsJS = List(
-  tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "1.2.0").toMap,
+  tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "1.2.0").toMap
 )
 lazy val jawnSettingsNative = Seq(
   tlVersionIntroduced := Map(

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "1.4"
+ThisBuild / tlBaseVersion := "1.5"
 lazy val scala212 = "2.12.17"
 lazy val scala213 = "2.13.10"
 lazy val scala3 = "3.2.2"

--- a/parser/js/src/main/scala/jawn/Platform.scala
+++ b/parser/js/src/main/scala/jawn/Platform.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.jawn
+
+private object Platform {
+  final val isJvm = false
+  final val isJs = true
+  final val isNative = false
+}

--- a/parser/jvm/src/main/scala/jawn/Platform.scala
+++ b/parser/jvm/src/main/scala/jawn/Platform.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.jawn
+
+private object Platform {
+  final val isJvm = true
+  final val isJs = false
+  final val isNative = false
+}

--- a/parser/native/src/main/scala/jawn/Platform.scala
+++ b/parser/native/src/main/scala/jawn/Platform.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.typelevel.jawn
+
+private object Platform {
+  final val isJvm = false
+  final val isJs = false
+  final val isNative = true
+}

--- a/parser/shared/src/main/scala/jawn/ByteArrayParser.scala
+++ b/parser/shared/src/main/scala/jawn/ByteArrayParser.scala
@@ -40,11 +40,29 @@ final class ByteArrayParser[J](src: Array[Byte]) extends SyncParser[J] with Byte
     context: FContext[J],
     stack: List[FContext[J]]
   ): Unit = {}
-  final protected[this] def byte(i: Int): Byte = src(i)
-  final protected[this] def at(i: Int): Char = src(i).toChar
 
-  final protected[this] def at(i: Int, k: Int): CharSequence =
+  final protected[this] def byte(i: Int): Byte = {
+    if (Platform.isJs) {
+      if (i < 0 || i >= src.length) throw new ArrayIndexOutOfBoundsException
+    }
+    src(i)
+  }
+
+  final protected[this] def at(i: Int): Char = {
+    if (Platform.isJs) {
+      if (i < 0 || i >= src.length) throw new ArrayIndexOutOfBoundsException
+    }
+    src(i).toChar
+  }
+
+  final protected[this] def at(i: Int, k: Int): CharSequence = {
+    if (Platform.isJs) {
+      if (i < 0 || i >= src.length) throw new ArrayIndexOutOfBoundsException
+      if (k < 0 || k > src.length) throw new ArrayIndexOutOfBoundsException
+      if (i > k) throw new ArrayIndexOutOfBoundsException
+    }
     new String(src, i, k - i, utf8)
+  }
 
   final protected[this] def atEof(i: Int): Boolean = i >= src.length
 }

--- a/parser/shared/src/main/scala/jawn/CharSequenceParser.scala
+++ b/parser/shared/src/main/scala/jawn/CharSequenceParser.scala
@@ -34,8 +34,20 @@ final private[jawn] class CharSequenceParser[J](cs: CharSequence) extends SyncPa
   final protected[this] def line(): Int = _line
   final protected[this] def reset(i: Int): Int = i
   final protected[this] def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]): Unit = ()
-  final protected[this] def at(i: Int): Char = cs.charAt(i)
-  final protected[this] def at(i: Int, j: Int): CharSequence = cs.subSequence(i, j)
+  final protected[this] def at(i: Int): Char = {
+    if (Platform.isJs) {
+      if (i < 0 || i >= cs.length) throw new IndexOutOfBoundsException
+    }
+    cs.charAt(i)
+  }
+  final protected[this] def at(i: Int, j: Int): CharSequence = {
+    if (Platform.isJs) {
+      if (i < 0 || i >= cs.length) throw new IndexOutOfBoundsException
+      if (j < 0 || j > cs.length) throw new IndexOutOfBoundsException
+      if (i > j) throw new IndexOutOfBoundsException
+    }
+    cs.subSequence(i, j)
+  }
   final protected[this] def atEof(i: Int): Boolean = i == cs.length
   final protected[this] def close(): Unit = ()
 }

--- a/parser/shared/src/main/scala/jawn/StringParser.scala
+++ b/parser/shared/src/main/scala/jawn/StringParser.scala
@@ -39,8 +39,20 @@ final private[jawn] class StringParser[J](s: String) extends SyncParser[J] with 
   final protected[this] def line(): Int = _line
   final protected[this] def reset(i: Int): Int = i
   final protected[this] def checkpoint(state: Int, i: Int, context: FContext[J], stack: List[FContext[J]]): Unit = {}
-  final protected[this] def at(i: Int): Char = s.charAt(i)
-  final protected[this] def at(i: Int, j: Int): CharSequence = s.substring(i, j)
+  final protected[this] def at(i: Int): Char = {
+    if (Platform.isJs) {
+      if (i < 0 || i >= s.length) throw new StringIndexOutOfBoundsException
+    }
+    s.charAt(i)
+  }
+  final protected[this] def at(i: Int, j: Int): CharSequence = {
+    if (Platform.isJs) {
+      if (i < 0 || i >= s.length) throw new StringIndexOutOfBoundsException
+      if (j < 0 || j > s.length) throw new StringIndexOutOfBoundsException
+      if (i > j) throw new StringIndexOutOfBoundsException
+    }
+    s.substring(i, j)
+  }
   final protected[this] def atEof(i: Int): Boolean = i == s.length
   final protected[this] def close(): Unit = ()
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.20")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.4")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.1")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.1")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.19")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.4")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.1")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.typelevel" % "sbt-typelevel" % "0.4.19")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.4")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.13.1")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.12")

--- a/util/shared/src/main/scala/jawn/util/package.scala
+++ b/util/shared/src/main/scala/jawn/util/package.scala
@@ -45,6 +45,9 @@ package object util {
     var inverseSign: Long = -1L
     var i: Int = 0
 
+    if (cs.length == 0)
+      throw InvalidLong(cs.toString)
+
     if (cs.charAt(0) == '-') {
       inverseSign = 1L
       i = 1


### PR DESCRIPTION
Follow-up to https://github.com/typelevel/jawn/pull/535#discussion_r1203157662. On Scala.js, index-out-of-bounds is undefined behavior. 

> Because Scala.js does not receive VM support to detect such erroneous conditions, checking them is typically too expensive.

https://www.scala-js.org/doc/semantics.html#undefined-behaviors

Jawn relies on these exceptions to detect parsing failures, so for correctness we rely on well-defined behavior. Thus this PR manually restores the out-of-bounds checks for JS only.

Inline comments incoming.