### PR TITLE
Optimize UnwrapArray parser by caching JValue ClassTag

### DIFF
--- a/ast/shared/src/main/scala/jawn/ast/JValue.scala
+++ b/ast/shared/src/main/scala/jawn/ast/JValue.scala
@@ -22,8 +22,9 @@
 package org.typelevel.jawn
 package ast
 
-import java.lang.Double.{isInfinite, isNaN}
+import java.lang.Double.{ isInfinite, isNaN }
 import scala.collection.mutable
+import scala.reflect.ClassTag
 import scala.util.hashing.MurmurHash3
 
 class WrongValueException(e: String, g: String) extends Exception(s"expected $e, got $g")
@@ -81,6 +82,7 @@ sealed abstract class JValue {
 
 object JValue {
   implicit val facade: Facade[JValue] = JawnFacade
+  implicit val classTag: ClassTag[JValue] = ClassTag(classOf[JValue])
 }
 
 sealed abstract class JAtom extends JValue {

--- a/ast/shared/src/main/scala/jawn/ast/JawnFacade.scala
+++ b/ast/shared/src/main/scala/jawn/ast/JawnFacade.scala
@@ -53,7 +53,7 @@ object JawnFacade extends Facade.NoIndexFacade[JValue] {
       private[this] val vs = mutable.ArrayBuffer.empty[JValue]
       def add(s: CharSequence): Unit = vs += JString(s.toString)
       def add(v: JValue): Unit = vs += v
-      def finish(): JValue = JArray(vs.toArray)
+      def finish(): JValue = JArray(vs.toArray(JValue.classTag))
       def isObj: Boolean = false
     }
 


### PR DESCRIPTION
While using the `UnwrapArray` parsing mode, I can see a very large amount of `java.lang.ClassValue` calls.

![classtag](https://github.com/typelevel/jawn/assets/606963/545f5113-8415-4c96-b1f6-3392fe91e706)

This accounts for almost 30% of CPU time for very large inputs.

This PR proposes to cache an implicit `ClassTag` value for the `JValue` in order to speed things up.

I was unfortunately not able to validate the fix as I have issues producing snapshots locally.