### PR TITLE
Upgrade to scalacheck 1.18.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ ThisBuild / tlFatalWarnings := false
 
 lazy val jawnSettings = Seq(
   Test / testOptions += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "1"),
-  libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.17.1" % Test
+  libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.18.0" % Test
 )
 
 lazy val jawnSettingsJVM = List(Test / fork := true)


### PR DESCRIPTION
based on https://github.com/typelevel/jawn/pull/631

Change scalacheck version

This is part of unblocking circe.

The previous one was closed by typelevel bot.